### PR TITLE
Fixes logo session creating incorrectly named files.

### DIFF
--- a/wxMain.cpp
+++ b/wxMain.cpp
@@ -39,6 +39,7 @@ extern "C" int stop_quietly_flag;
 // externs from the logo interpreter 
 extern "C" int start (int , char **);
 extern "C" void redraw_graphics(); 
+extern "C" char *strnzcpy(char *, char *, int);
 
 // need to redraw turtle graphics
 int needToRefresh = 0;
@@ -46,8 +47,6 @@ int needToRefresh = 0;
 
 // IO buffer handling
 char nameBuffer [NAME_BUFFER_SIZE];
-int nameBufferSize = 0;
-
 
 char output_buffer[MAXOUTBUFF];
 int output_index = 0;
@@ -202,28 +201,16 @@ extern "C" void getExecutableDir(char * path, int maxlen) {
 }
 
 
-void doLoad(char * name, int length) {
-  int i = 0;
-  while (i < length && i < NAME_BUFFER_SIZE) {
-    nameBuffer[i] = name[i];
-    i++;
-  }
-  nameBufferSize = (length >= NAME_BUFFER_SIZE? NAME_BUFFER_SIZE : length);
-
-    (void)lload(cons(make_static_strnode(name),NIL));
+void doLoad(char * name) {
+    strnzcpy(nameBuffer, name, NAME_BUFFER_SIZE - 1);
+    (void)lload(cons(make_static_strnode(nameBuffer),NIL));
     stop_quietly_flag = 1;
     logo_stop_flag = 1;
 }
 
-void doSave(char * name, int length) {
-  int i = 0;
-  while (i < length && i < NAME_BUFFER_SIZE) {
-    nameBuffer[i] = name[i];
-    i++;
-  }
-  nameBufferSize = (length >= NAME_BUFFER_SIZE? NAME_BUFFER_SIZE : length);
-  
-    (void)lsave(cons(make_static_strnode(name),NIL));
+void doSave(char * name) {
+    strnzcpy(nameBuffer, name, NAME_BUFFER_SIZE - 1);
+    (void)lsave(cons(make_static_strnode(nameBuffer),NIL));
     stop_quietly_flag = 1;
     logo_stop_flag = 1;
   }

--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -477,15 +477,15 @@ extern "C" void new_line(FILE *);
 int firstloadsave = 1;
 extern "C" void *save_name;
 
-void doSave(char * name, int length);
-void doLoad(char * name, int length);
+void doSave(char * name);
+void doLoad(char * name);
 
 extern "C" void *cons(void*, void*);
 extern "C" void lsave(void*);
 
 void LogoFrame::OnSave(wxCommandEvent& event) {
-    if (save_name != NULL) {
-	lsave(cons(save_name, NULL));
+    if (save_name != NIL) {
+	lsave(cons(save_name, NIL));
     } else {
 	OnSaveAs(event);
     }
@@ -504,8 +504,7 @@ void LogoFrame::OnSaveAs(wxCommandEvent& WXUNUSED(event)) {
 //	dialog.SetFilterIndex(1);
 	if (dialog.ShowModal() == wxID_OK)
 	{
-	    doSave((char *)dialog.GetPath().char_str(wxConvUTF8),
-		   dialog.GetPath().length());
+	    doSave((char *)dialog.GetPath().char_str(wxConvUTF8));
 	    new_line(stdout);
 	}
     firstloadsave = 0;
@@ -524,8 +523,7 @@ void LogoFrame::OnLoad(wxCommandEvent& WXUNUSED(event)){
 	 );
 		
 	if (dialog.ShowModal() == wxID_OK) {
-	    doLoad((char *)dialog.GetPath().char_str(wxConvUTF8),
-		   dialog.GetPath().length());
+	    doLoad((char *)dialog.GetPath().char_str(wxConvUTF8));
 	    new_line(stdout);
 	}
     firstloadsave = 0;


### PR DESCRIPTION
Closes #39
Also removes unneeded global nameBufferSize.
Patch from @zigggit
