### PR TITLE
ISSUE-44: Manually convert ASCII buffer into wxString during copy operation so clipboard is populated

### DIFF
--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -1961,7 +1961,7 @@ wxTerminal::GetChars(int x1, int y1, int x2, int y2)
 
   while(a.buf != b.buf) {
     //  size 10, offset 5,  copy 10-5=5 chars... yup
-    ret.Append((wxChar*)a.buf->cbuf+a.offset, WXTERM_CB_SIZE-a.offset);
+    ret.Append(wxString::FromAscii(a.buf->cbuf+a.offset, WXTERM_CB_SIZE-a.offset));
     if(a.buf->next) {
       a.offset = 0;
       a.buf = a.buf->next;
@@ -1971,7 +1971,7 @@ wxTerminal::GetChars(int x1, int y1, int x2, int y2)
       fprintf(stderr, "BAD (getchars)\n");
     }
   }
-  ret.Append((wxChar*)a.buf->cbuf+a.offset, b.offset - a.offset);
+  ret.Append(wxString::FromAscii(a.buf->cbuf+a.offset, b.offset - a.offset));
   return ret;
 }
 


### PR DESCRIPTION
On OSX Catalina 10.15.6 with wxWidgets 3.0.5 this appears to address Issue #44 - "Can't select/copy text"

Caveat: On my machine, the text is not highlighted during the select; but, does appear to properly populate the clipboard.

Please let me know if there's anything else I need to do for this to be an appropriate PR. I have not tested this on Windows ~or Linux~; but, am happy to do so if that helps.

[EDIT: I setup a VM running Ubuntu Bionic with wxWidgets 3.0.5 and the code change seems to work there as well]