### PR TITLE
ISSUE-60: Fixed a couple of OSX GUI issues.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -47,11 +47,6 @@ wxTextCtrl(f, a, s, p, sz, b)
 void TextEditor::SetFont(wxFont font){
 	this->font = font;
 	SetForegroundColour(TurtleCanvas::colors[wxTerminal::terminal->m_curFG]);
-#ifdef __WXMAC__                                                        
-	SetDefaultStyle(wxTextAttr(wxNullColour,wxNullColour, font));
-	if(this->IsShown()){
-		SetStyle(0,GetLastPosition(), wxTextAttr(wxNullColour,wxNullColour,font));
-#else
 	SetDefaultStyle(wxTextAttr(TurtleCanvas::colors[wxTerminal::terminal->m_curFG],
 				   TurtleCanvas::colors[wxTerminal::terminal->m_curBG], font));
 	if(this->IsShown()){
@@ -60,18 +55,12 @@ void TextEditor::SetFont(wxFont font){
 				    TurtleCanvas::colors[wxTerminal::terminal->m_curBG],font));
     SetBackgroundColour(
 		TurtleCanvas::colors[wxTerminal::terminal->m_curBG]);
-#endif
 		Refresh();
 		Update();
 	}
 }
 
 void TextEditor::SetThisFont(wxCommandEvent& event) {
-#ifdef __WXMAC__                                                        
-	SetDefaultStyle(wxTextAttr(wxNullColour,wxNullColour, this->font));
-	if(this->IsShown()){
-		SetStyle(GetLastPosition()-1, GetLastPosition(), wxTextAttr(wxNullColour,wxNullColour,this->font));
-#else
 	SetDefaultStyle(wxTextAttr(TurtleCanvas::colors[wxTerminal::terminal->m_curFG],
 				   TurtleCanvas::colors[wxTerminal::terminal->m_curBG], this->font));
 	if(this->IsShown()){
@@ -80,7 +69,6 @@ void TextEditor::SetThisFont(wxCommandEvent& event) {
 				    TurtleCanvas::colors[wxTerminal::terminal->m_curBG],this->font));
 	    SetBackgroundColour(
 			TurtleCanvas::colors[wxTerminal::terminal->m_curBG]);
-#endif
 		Refresh();
 		Update();
 		Refresh();

--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -370,7 +370,7 @@ LogoFrame::LogoFrame (const wxChar *title,
 		wxEXPAND |    // make horizontally stretchable
 		wxALL,        //   and make border all around
 		2 ); 
-     
+  topsizer->Layout();
 
   topsizer->Show(wxTerminal::terminal, 1);
   topsizer->Show(turtleGraphics, 0);


### PR DESCRIPTION
Resolves #60 

* Explicitly call layout to prevent an issue where the top left corner of the terminal was obscured by the other widgets
* Removed wxWidgets 2.6 workaround which, in wxWidgets 3.0.x, causes the editor to use white for both foreground and background

Test Environments
=
OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.3) w/ wxWidgets 3.0.5
Windows 10 Home (1903) w/ wxWidgets 3.0.5

Context
=
* The changes appear to fix the two issues under OSX without introducing any negative behaviors under Linux or Windows.
* Looking at the commit message of the code on `TextEditor.cpp` (a3598a9b05befc6afc1e23463262cd9b3aa62501), it appears to be a specific workaround for wxWidgets 2.6 on Mac so hopefully safe to remove