### PR TITLE
ISSUE-43: Don't crash when using STOP in macro.

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -994,8 +994,11 @@ op_want_stop:
 		if (didnt_get_output == NIL || didnt_get_output == UNBOUND) {
 		/*  actually can happen: PRINT FOREACH ...
 		    will give didn't output message uplevel  */
-		} else
-		    err_logo(DIDNT_OUTPUT, NIL);
+                } else if (is_macro(fun)) {
+                    err_logo(ERR_MACRO, UNBOUND);
+                } else {
+                    err_logo(DIDNT_OUTPUT, NIL);
+                }
 	    }
 	} else {    /* show runresult [stop] inside a procedure */
 	    didnt_output_name = car(expresn);

--- a/tests/UnitTests-Macros.lg
+++ b/tests/UnitTests-Macros.lg
@@ -1,0 +1,94 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;                                        ;;
+;;             BERKELEY LOGO              ;;
+;;            Macro Unit Tests            ;;
+;;                                        ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+InstallSuite [Macros] [Tests.Macro.Setup]
+
+
+
+;; The list of all Macro unit tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+MAKE "Tests.Macro [
+  ;list tests here
+  Tests.Macro.OutputStopWorksAsExpected
+  Tests.Macro.PlainStopErrorsAsExpected
+  Tests.Macro.FunctionStopErrorsAsExpected
+]
+
+;; Test Suite setup procedure, main entry
+;; point for all tests in this suite
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to Tests.Macro.Setup
+  RunTests :Tests.Macro
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;                                 ;;
+;; HELPERS, MISC                   ;;
+;;                                 ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+.MACRO Tests.Macro._OutputStopMacro
+  OUTPUT [ STOP ]
+END
+
+TO Tests.Macro._CallOutputStop
+  Tests.Macro._OutputStopMacro
+  OUTPUT 1
+END
+
+.MACRO Tests.Macro._PlainStopMacro
+  STOP
+END
+
+TO Tests.Macro._StopFunction
+  STOP
+END
+
+TO Tests.Macro._CallStopFunction
+  OUTPUT Tests.Macro._StopFunction
+END
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;                                 ;;
+;; ADD INDIVIDUAL UNIT TESTS BELOW ;;
+;;                                 ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;all tests must return T/F indicating success/failure
+
+TO Tests.Macro.OutputStopWorksAsExpected
+  LOCALMAKE "result RUNRESULT [ Tests.Macro._CallOutputStop ]
+
+  OUTPUT EMPTY? :result
+END
+
+TO Tests.Macro.PlainStopErrorsAsExpected
+  CATCH "Error [ Tests.Macro._PlainStopMacro ]
+  LOCALMAKE "err ERROR
+
+  ; Message 29 is "Macro returned %s instead of a list"
+  OUTPUT (AND [NOT EMPTY? :err]
+              [EQUAL? FIRST :err 29])
+END
+
+
+;; Not strictly a macro test; but, the functionality to handle this error
+;; is closely related to the functionality to catch a macro directly
+;; calling stop
+
+TO Tests.Macro.FunctionStopErrorsAsExpected
+  CATCH "Error [ Tests.Macro._CallStopFunction ]
+  LOCALMAKE "err ERROR
+
+  ; Message 5 is "%p didn't output to %p"
+  OUTPUT (AND [NOT EMPTY? :err]
+              [EQUAL? FIRST :err 5])
+END

--- a/tests/UnitTests.lg
+++ b/tests/UnitTests.lg
@@ -110,6 +110,7 @@ end
 LOAD "UnitTests-Arithmetic.lg
 LOAD "UnitTests-Bitwise.lg
 LOAD "UnitTests-Constructors.lg
+LOAD "UnitTests-Macros.lg
 LOAD "UnitTests-Predicates.lg
 LOAD "UnitTests-Random.lg
 LOAD "UnitTests-MemMgr.lg


### PR DESCRIPTION
Resolves #43 

* Catch the case of a macro directly invoking `STOP` and return the appropriate error message
* Add unit tests to cover this and neighboring cases

Test Environments
=
OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1903) w/ wxWidgets 3.0.5

Test Cases
=
Original issue errors politely:
```logo
? .MACRO AA
>   STOP
> END
AA defined
? AA
Macro returned nothing instead of a list  in AA
[STOP]
? 
```
Error message for similarly problematic function does not change:
```logo
? TO StopFunction
>   STOP
> END
StopFunction defined
? TO CallStopFunction
>   OUTPUT StopFunction
> END
CallStopFunction defined
? CallStopFunction
StopFunction didn't output to OUTPUT  in CallStopFunction
[OUTPUT StopFunction]
? 
```
Behavior of properly structured macro does not change:
```logo
? .MACRO OutputStop
>   OUTPUT [ STOP ]
> END
OutputStop defined
? TO CallOutputStop
>   OutputStop
>   OUTPUT 1
> END
CallOutputStop defined
? CallOutputStop
? 
```

Caveats
=
* Unsure if adding to the unit test framework is fair game; but, figured I'd try to capture the original case and neighboring cases. Please let me know if the unit tests need to be changed, added, or removed.
* Wasn't sure the best way to verify specific error cases in the unit tests, so I'm proposing checking the initial error number in the message assuming this will stay consistent across locales.