### PR TITLE
ISSUE-63: Exit getFromWX_2 input loop on pause character sequence.

### DIFF
--- a/coms.c
+++ b/coms.c
@@ -24,7 +24,7 @@
 
 #ifdef HAVE_WX
 #define fgets wx_fgets
-extern int check_wx_stop(int force_yield);
+extern int check_wx_stop(int force_yield, int pause_return_value);
 #endif
 
 #define WANT_EVAL_REGS 1

--- a/eval.c
+++ b/eval.c
@@ -716,7 +716,7 @@ compound_apply:
     check_ibm_stop();
 #endif
 #ifdef HAVE_WX
-    check_wx_stop(0);
+    check_wx_stop(0, 0);
 #endif
     if ((tracing = flag__caseobj(fun, PROC_TRACED))) {
 	for (i = 0; i < trace_level; i++) print_space(writestream);

--- a/globals.h
+++ b/globals.h
@@ -22,7 +22,7 @@
 #ifdef HAVE_WX
 extern int start(int, char **);
 extern int wx_leave_mainloop;
-extern int check_wx_stop(int force_yield);
+extern int check_wx_stop(int force_yield, int pause_return_value);
 #endif
 extern NODE **bottom_stack; /*GC*/
 extern NODE *current_line, *exec_list;

--- a/logo.h
+++ b/logo.h
@@ -99,7 +99,7 @@ extern char *getenv();
 
 #ifdef HAVE_WX
 #undef ibm
-#define check_throwing (check_wx_stop(0) || stopping_flag == THROWING)
+#define check_throwing (check_wx_stop(0, 0) || stopping_flag == THROWING)
 #else
 #ifdef mac
 #define check_throwing (check_mac_stop() || stopping_flag == THROWING)

--- a/parse.c
+++ b/parse.c
@@ -68,7 +68,7 @@ extern int getch(void);
 #endif
 #define getc getFromWX_2
 #define getch getFromWX
-extern int check_wx_stop(int force_yield);
+extern int check_wx_stop(int force_yield, int pause_return_value);
 extern void wx_enable_scrolling();
 extern void wx_refresh();
 #endif

--- a/wxGlobals.h
+++ b/wxGlobals.h
@@ -89,7 +89,7 @@ extern wxMemoryDC *m_memDC;
 /* wxTextEdit */
 extern char * file; // using this is safe because the other thread is sleeping
 					// and it stack is also asleep
-extern "C" int check_wx_stop(int force_yield);
+extern "C" int check_wx_stop(int force_yield, int pause_return_value);
 extern "C" int internal_check();
 
 #define wxdprintf if (wx_Debugging) printf

--- a/wxMain.cpp
+++ b/wxMain.cpp
@@ -99,7 +99,7 @@ extern "C" void wxLogoSleep(unsigned int milli) {
     return;
   }
   while(wxDateTime::UNow().IsEarlierThan(stop_waiting)) {
-    if(check_wx_stop(1) || eval_buttonact) {  //force yielding
+    if(check_wx_stop(1, 0) || eval_buttonact) {  //force yielding
       break;
     }
     wx_refresh();
@@ -164,7 +164,7 @@ extern "C" char getFromWX_2(FILE * f)
       wxdprintf("after wxMain calling refresh()");	  
     }
     // Do this while the lock is released just in case the longjump occurs
-    if (check_wx_stop(1)) {   // force yield (1)
+    if (check_wx_stop(1, 1)) {   // force yield (1)
       putReturn = 1;
     }
     flushFile(stdout);

--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -2647,7 +2647,7 @@ extern "C" void wx_enable_scrolling() {
 extern enum s_md {SCREEN_TEXT, SCREEN_SPLIT, SCREEN_FULL} screen_mode;
 
 
-extern "C" int check_wx_stop(int force_yield) {
+extern "C" int check_wx_stop(int force_yield, int pause_return_value) {
   logoEventManager->ProcessEvents(force_yield); 
 
   //give focus to terminal if text window shown
@@ -2676,7 +2676,7 @@ extern "C" int check_wx_stop(int force_yield) {
 #else
     logo_pause();
 #endif
-    return 0;
+    return pause_return_value;
   }
   return 0;
 }

--- a/wxTurtleGraphics.cpp
+++ b/wxTurtleGraphics.cpp
@@ -493,7 +493,7 @@ void TurtleCanvas::editCall(){
   editWindow->Load(wxString(file,wxConvUTF8));
   //need to busy wait and handle events...
   while(editor_active) {
-    if(check_wx_stop(1))
+    if(check_wx_stop(1, 0))
       break; 
     wxMilliSleep(10);
   }


### PR DESCRIPTION
Resolves #63 
* Fix bug where a pause character sequence during trace hangs when the CONTINUE command is given

Test Environments
=
OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1903) w/ wxWidgets 3.0.5

Caveat
=
The addition of the second parameter flag was the best way I could think of to not change the behavior except in the case of the user input loop. Please let me know if there is a safe approach which is more elegant.
