### PR TITLE
ISSUE-47: Fixed resize bug causing ghost turtle.

### DIFF
--- a/graphics.c
+++ b/graphics.c
@@ -159,7 +159,12 @@ void draw_turtle(void) {
     int save_vis;
 
 #ifdef HAVE_WX
-    if (drawToPrinter) return;
+    // Support for XOR drawing in wxWidgets is currently platform
+    // dependent and likely to go away in the future.
+    // See: http://trac.wxwidgets.org/ticket/18050
+    //
+    // So, drawing the turtle is handled manually at the wx level.
+    return;
 #endif
 
     if (!turtle_shown) {

--- a/wxTurtleGraphics.cpp
+++ b/wxTurtleGraphics.cpp
@@ -304,9 +304,8 @@ void TurtleCanvas::OnSize(wxSizeEvent& event) {
   setInfo(SCREEN_HEIGHT, screen_height);
 
 #if USE_MEMDC  
-  m_memDC->SetDeviceOrigin( (m_w - screen_width)/2, 
-			    (m_h - screen_height)/2 );
-  
+  m_memDC->SetDeviceOrigin(m_w/2 - screen_width/2,
+                           m_h/2 - screen_height/2);
 #endif
 
   wxClientDC dc(this);


### PR DESCRIPTION
Resolves #47 

On certain window sizes, rounding on the original resize calculation was causing small shifts in the turtle position. On systems where the XOR turtle drawing works, this resulted in ghost turtles. On other systems, there was no ghost turtle; but, post-resize drawn lines could still be misaligned from pre-resize drawn lines.

Additionally, this commit stops the turtle from being drawn in `graphics.c` if it is going to be drawn in wx in order to prevent small gaps in lines if XOR is not supported on the system. As an example, the following is the result of repeatedly typing `fd 6` with a few resizes in the middle on a Linux system that doesn't handle XOR:
![ISSUE-47-linux-dashed-line](https://user-images.githubusercontent.com/330202/98455982-a5059a80-2145-11eb-8a1e-4181d100f4de.png)

Test Environments
=
OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1903) w/ wxWidgets 3.0.5