### PR TITLE
FEATURE-CI: Initial pass at having a CI build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: >
+        sudo apt-get install
+        autoconf-archive
+        libwxgtk3.0-dev
+    - name: Build Logo
+      run: |
+        autoreconf --install
+        ./configure --enable-objects --enable-gitid --disable-docs
+        make
+    - name: Run Tests
+      timeout-minutes: 2
+      env:
+        LOGOLIB: ${{ github.workspace }}/logolib
+      working-directory: tests
+      run: >
+        xvfb-run
+        -e /dev/stdout
+        --auto-servernum
+        $GITHUB_WORKSPACE/ucblogo UnitTests.lg
+        -
+        -f $GITHUB_WORKSPACE/logo-unit-test-results.txt
+        -x
+    - name: Grade Tests
+      # Add an error annotation to the job for each test that failed or had an error.
+      # Fail the step (and job) if any tests failed or had an error.
+      run: |
+        awk '/\.\.\./ && ! /Ok$/{print "::error::"$0}' logo-unit-test-results.txt
+        awk "/\.\.\./ && ! /Ok$/{exit 1}" logo-unit-test-results.txt	
+    - name: Archive Test Results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: Logo Unit Test Results
+        path: logo-unit-test-results.txt

--- a/tests/UnitTests-Random.lg
+++ b/tests/UnitTests-Random.lg
@@ -49,8 +49,7 @@ end
 
 to Tests.Random.RandomNumDyadic
   Make "Num3 (Random 3 5)
-  print (AND [(Random -1 0) = -1]
-              [GreaterEqual? :num3 3]
+  OUTPUT (AND [GreaterEqual? :num3 3]
               [LessEqual? :num3 5])
 end
 

--- a/tests/UnitTests.lg
+++ b/tests/UnitTests.lg
@@ -115,3 +115,39 @@ LOAD "UnitTests-Predicates.lg
 LOAD "UnitTests-Random.lg
 LOAD "UnitTests-MemMgr.lg
 LOAD "UnitTests-OOP.lg
+
+
+;; Process any command line options
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to ProcessCommandLineArgs :Args
+  IF EMPTY? :Args [ STOP ]
+  IF EQUAL? FIRST :Args "-x [
+    MAKE "RunAndExit "True
+    ProcessCommandLineArgs BUTFIRST :Args
+    STOP
+  ]
+  IF EQUAL? FIRST :Args "-f [
+    IFELSE NOT EMPTY? BUTFIRST :Args [
+      MAKE "OutputFilename FIRST BUTFIRST :Args
+      ProcessCommandLineArgs BUTFIRST BUTFIRST :Args
+      STOP
+    ] [
+      PRINT [not enough inputs to -f]
+      STOP
+    ]
+  ]
+  PRINT SENTENCE [I don't know how to] FIRST :Args
+  ProcessCommandLineArgs BUTFIRST :Args
+end
+
+ProcessCommandLineArgs :COMMAND.LINE
+
+IF NAME? "OutputFilename [
+  OPENWRITE :OutputFilename SETWRITE :OutputFilename
+]
+
+IF NAME? "RunAndExit [
+  RunAll
+  BYE
+]


### PR DESCRIPTION
Submitting this PR as a proposal - using the unit tests on a few things, I started thinking that CI might be nice. That said, I'm unsure if that's in alignment with the overall project goals. I thought a working example might be a good way to discuss it.

In Action
===
A run triggered by a push to the watched branch:
https://github.com/dmalec/ucblogo-code/actions/runs/358611666

A PR with a change that causes a unit test to fail: https://github.com/dmalec/ucblogo-code/pull/2
*PR View:*
![Screen Shot 2020-11-11 at 6 09 06 PM](https://user-images.githubusercontent.com/330202/98874884-18aaee80-2449-11eb-8236-a7ae2e873d1c.png)
*Details Link View:*
![Screen Shot 2020-11-11 at 6 09 20 PM](https://user-images.githubusercontent.com/330202/98874937-32e4cc80-2449-11eb-957e-d22ad3c3697a.png)

A PR with a change that passes the unit tests: https://github.com/dmalec/ucblogo-code/pull/3
*PR View:*
![Screen Shot 2020-11-11 at 6 08 51 PM](https://user-images.githubusercontent.com/330202/98874879-15176780-2449-11eb-80ed-8b48b6fc8853.png)

Overview
===
1. The CI does an `autoreconf/configure/make` cycle and then invokes Logo (wrapped by `xvfb-run`).
2. The results are output to a file which is parsed using `awk` to determine if any errors or failures happened.
3. The file is also saved as an artifact.

Nuances
===
* I wasn't sure how command line arguments might look so as to be as Logo friendly as possible; but, am putting this forward as one possible approach.
* I did update the dyadic random number test so it passes rather than errors in order to get to an "all green" starting point.
* I think there's ways to improve the specificity of the unit test report; but, figured this was a reasonable point to break at and see if the overall idea resonated :)