### PR TITLE
ISSUE-51: Improve UX / fix bugs related to char buffer output.

### DIFF
--- a/tests/UnitTests-Files.lg
+++ b/tests/UnitTests-Files.lg
@@ -1,0 +1,132 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;                                        ;;
+;;             BERKELEY LOGO              ;;
+;;           File Access Tests            ;;
+;;                                        ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+InstallSuite [Files] [Tests.File.Setup]
+
+
+
+;; The list of all File unit tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+MAKE "Tests.File [
+  ;list tests here
+  Tests.File.WriteToCharBuffer
+  Tests.File.LegacyWriteToCharBuffer
+  Tests.File.InterleaveCharBufferWrites
+  Tests.File.OpenWriteCharBufferArgError
+  Tests.File.SetWriteCharBufferArgError
+]
+
+;; Test Suite setup procedure, main entry
+;; point for all tests in this suite
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+to Tests.File.Setup
+  RunTests :Tests.File
+end
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;                                 ;;
+;; HELPERS, MISC                   ;;
+;;                                 ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;                                 ;;
+;; ADD INDIVIDUAL UNIT TESTS BELOW ;;
+;;                                 ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;all tests must return T/F indicating success/failure
+
+TO Tests.File.WriteToCharBuffer
+  LOCALMAKE "char.buffer [buffer 10]
+  LOCALMAKE "saved.writer WRITER
+
+  OPENWRITE :char.buffer
+  SETWRITE :char.buffer
+  TYPE "01234
+  CLOSE :char.buffer
+  LOCALMAKE "short :buffer
+
+  OPENWRITE :char.buffer
+  SETWRITE :char.buffer
+  TYPE "0123456789
+  CLOSE :char.buffer
+  LOCALMAKE "boundary :buffer
+
+  OPENWRITE :char.buffer
+  SETWRITE :char.buffer
+  TYPE "0123456789ABCDEF
+  CLOSE :char.buffer
+  LOCALMAKE "long :buffer
+
+  SETWRITE :saved.writer
+
+  OUTPUT (AND [EQUAL? :short "01234]
+              [EQUAL? :boundary "0123456789]
+              [EQUAL? :long "0123456789])
+END
+
+TO Tests.File.LegacyWriteToCharBuffer
+  LOCALMAKE "char.buffer [buffer 10]
+  LOCALMAKE "saved.writer WRITER
+
+  SETWRITE :char.buffer
+  TYPE "hello
+  SETWRITE []
+
+  SETWRITE :saved.writer
+
+  OUTPUT EQUAL? :buffer "hello
+END
+
+TO Tests.File.InterleaveCharBufferWrites
+  LOCALMAKE "char.buffer.A [buffer.A 10]
+  LOCALMAKE "char.buffer.B [buffer.B 10]
+  LOCALMAKE "saved.writer WRITER
+
+  OPENWRITE :char.buffer.A
+  OPENWRITE :char.buffer.B
+
+  SETWRITE :char.buffer.A
+  TYPE "he
+  SETWRITE :char.buffer.B
+  TYPE "wo
+  SETWRITE :char.buffer.A
+  TYPE "llo
+  SETWRITE :char.buffer.B
+  TYPE "rld
+
+  CLOSE :char.buffer.A
+  CLOSE :char.buffer.B
+
+  SETWRITE :saved.writer
+
+  OUTPUT (AND [EQUAL? :buffer.A "hello]
+              [EQUAL? :buffer.B "world])
+END
+
+TO Tests.File.OpenWriteCharBufferArgError
+  CATCH "Error [ OPENWRITE [SINGLEARG] ]
+  LOCALMAKE "err ERROR
+
+  ; Message 4 is "%p doesn't like %s as input"
+  OUTPUT (AND [NOT EMPTY? :err]
+              [EQUAL? FIRST :err 4])
+END
+
+TO Tests.File.SetWriteCharBufferArgError
+  CATCH "Error [ SETWRITE [SINGLEARG] ]
+  LOCALMAKE "err ERROR
+
+  ; Message 4 is "%p doesn't like %s as input"
+  OUTPUT (AND [NOT EMPTY? :err]
+              [EQUAL? FIRST :err 4])
+END

--- a/tests/UnitTests.lg
+++ b/tests/UnitTests.lg
@@ -110,6 +110,7 @@ end
 LOAD "UnitTests-Arithmetic.lg
 LOAD "UnitTests-Bitwise.lg
 LOAD "UnitTests-Constructors.lg
+LOAD "UnitTests-Files.lg
 LOAD "UnitTests-Macros.lg
 LOAD "UnitTests-Predicates.lg
 LOAD "UnitTests-Random.lg


### PR DESCRIPTION
Resolves #51 

Summary
=
* `OPENWRITE` checks list length before attempting to access buffer size
* `SETWRITE` checks list length before attempting to access buffer size
* When writing to a buffer, allocate one extra byte for null terminator
* Zero out allocated buffer to prevent left over data from appearing

Details
=
The original bug stated that `SETWRITE [WORD]` causes a crash. The root cause was `SETWRITE` assuming a list parameter would have two items and not checking before dereferencing the second item. This crash condition also appeared in `OPENWRITE [WORD]`.

While testing those two fixes, I noticed that, if the data written in Logo is longer than the buffer, it is not properly `NULL` terminated on the C side of things. The following snippet fairly reliably demonstrates the issue:
```
MAKE "char.buffer [buffer 10]

REPEAT 10 [
  OPENWRITE :char.buffer
  SETWRITE :char.buffer
  TYPE "0123456789ABCDEF
  CLOSE :char.buffer
  PRINT :buffer
]
```
Yielding:
```
012345678fTû
012345678fTû
012345678½fTû
012345678fTû
012345678fTû
012345678gSû
012345678gTû
012345678-gTû
012345678gTû
012345678gTû
```

The last issue is that allocating a buffer of 10 in Logo gives 9 writeable characters (since the 10th is reserved for a `NULL` terminator on the C side). I tweaked the code to allocate one extra space for the `NULL` character so that this detail isn't exposed on the Logo side of things.

Test Environments
=
OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1909) w/ wxWidgets 3.0.5