### PR TITLE
HOTFIX ISSUE-69: Added declaration of linemode_on to fix compile error in some OSX environments

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -428,6 +428,7 @@ extern int interactive;
 extern void term_init(void);
 extern void charmode_on(void);
 extern void charmode_off(void);
+extern void linemode_on(void);
 extern NODE *lcleartext(NODE *);
 extern NODE *lcursor(NODE *);
 extern NODE *lsetcursor(NODE *);


### PR DESCRIPTION
Mea culpa - I didn't notice the warning message when compiling in my OSX environment.

GitHub's OSX runners view this as a compiler error; so, in addition to wanting to not add a warning, I'm also concerned I may have introduced a compilation problem for others.