### PR TITLE
CD workflow - build (but do not release) release candidate artifacts.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -20,37 +20,6 @@ jobs:
   # over 30 minutes to build.
   # ############################################################################
 
-  build_wxwidgets_linux:
-    name: Build wxWidgets for Linux
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-    - name: Cache wxWidgets
-      uses: actions/cache@v2
-      id: wxwidgets-cache
-      with:
-        path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
-        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
-    - name: Install Dependencies
-      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
-      run: >
-        sudo apt-get install
-        libgtk-3-dev
-    - name: Download wxWidgets
-      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
-      working-directory: ${{ runner.temp }}
-      run: |
-        wget https://github.com/wxWidgets/wxWidgets/releases/download/v${{ env.WX_WIDGETS_VERSION }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}.tar.bz2
-        tar -xjf wxWidgets-${{ env.WX_WIDGETS_VERSION }}.tar.bz2
-    - name: Build wxwidgets
-      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
-      working-directory: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
-      run: |
-        mkdir build-static
-        cd build-static
-        ../configure --disable-shared --enable-unicode
-        make -j2
-
   build_wxwidgets_osx:
     name: Build wxWidgets for OSX
     runs-on: macos-latest
@@ -94,8 +63,9 @@ jobs:
       with:
         msystem: MINGW32
         install: >
-          make
-          mingw-w64-i686-gcc
+          git
+          base-devel
+          mingw-w64-i686-toolchain
           unzip
     - name: Download wxWidgets
       if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
@@ -110,7 +80,12 @@ jobs:
     - name: Build wxWidgets
       if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
       working-directory: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}\build\msw
-      shell: bash
+      shell: msys2 {0}
+      env:
+        # NOTE: wxWidgets 3.1.x has a fix for the narrowing issue; but, this
+        # approach should work for now given with wxWidgets 3.0.x
+        CFLAGS: -Wno-narrowing
+        CXXFLAGS: -Wno-narrowing
       # NOTE: using -j2 appears to cause problems on the MinGW builds
       run: |
         mingw32-make -f makefile.gcc SHARED=0 UNICODE=1 BUILD=release clean
@@ -125,7 +100,6 @@ jobs:
 
   build_linux:
     name: Build Logo for Linux
-    needs: build_wxwidgets_linux
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -136,20 +110,14 @@ jobs:
         libwxgtk3.0-dev
         texlive
         zip
-    - name: wxWidgets Cache
-      uses: actions/cache@v2
-      id: wxwidgets-cache
-      with:
-        path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
-        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
     - name: Checkout Repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Build Logo
-      env:
-        WX_CONFIG_PATH: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}/build-static/wx-config
       run: |
         autoreconf --install
-        ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH
+        ./configure --enable-gitid
         make -j2 dist
         make -j2 dist-zip
     - name: Archive ucblogo.tar.gz
@@ -190,6 +158,8 @@ jobs:
         key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
     - name: Checkout Repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Download PDF manual
       uses: actions/download-artifact@v2
       with:
@@ -243,8 +213,10 @@ jobs:
       with:
         msystem: MINGW32
         install: >
-          make
-          mingw-w64-i686-gcc
+          git
+          base-devel
+          mingw-w64-i686-toolchain
+          unzip
     - name: Inno Cache
       uses: actions/cache@v2
       id: inno-cache
@@ -264,8 +236,10 @@ jobs:
         key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
     - name: Checkout Repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Prepare Repository
-      shell: bash
+      shell: msys2 {0}
       run: |
         git clean -x -d -f .
         mingw32-make -f makefile.msys git.c
@@ -275,16 +249,19 @@ jobs:
       with:
         name: ucblogo.pdf
         path: docs
+    - name: Find MinGW bin directory
+      shell: msys2 {0}
+      run: |
+        echo "MINGW_BIN_DIR=`dirname $(command -v gcc)`" >> $GITHUB_ENV
     - name: Build Logo
-      shell: bash
+      shell: msys2 {0}
       env:
-        MINGW_BIN_DIR: D:\a\_temp\msys\msys64\mingw32\bin
         WX_DIR: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
       run: |
         mingw32-make -f makefile.msys MINGW_BIN_DIR=$MINGW_BIN_DIR WX_DIR=$WX_DIR install_win
     - name: Run Inno
       working-directory: ${{ github.workspace }}\inno
-      shell: bash
+      shell: pwsh
       run: |
         iscc ucblogo.iss
     - name: Archive installer

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,294 @@
+name: CD
+
+on:
+  push:
+    branches:
+    - cd_*
+    - master
+    - release*
+
+env:
+  INNO_VERSION: 6.1.2
+  WX_WIDGETS_VERSION: 3.0.5
+
+jobs:
+
+  # ############################################################################
+  # The build_wxwidgets_<platform> jobs handle building and caching wxWidgets.
+  #
+  # This reduces total build time by a measurable amount, as wxWidgets can take
+  # over 30 minutes to build.
+  # ############################################################################
+
+  build_wxwidgets_linux:
+    name: Build wxWidgets for Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Cache wxWidgets
+      uses: actions/cache@v2
+      id: wxwidgets-cache
+      with:
+        path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+    - name: Install Dependencies
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      run: >
+        sudo apt-get install
+        libgtk-3-dev
+    - name: Download wxWidgets
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}
+      run: |
+        wget https://github.com/wxWidgets/wxWidgets/releases/download/v${{ env.WX_WIDGETS_VERSION }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}.tar.bz2
+        tar -xjf wxWidgets-${{ env.WX_WIDGETS_VERSION }}.tar.bz2
+    - name: Build wxwidgets
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+      run: |
+        mkdir build-static
+        cd build-static
+        ../configure --disable-shared --enable-unicode
+        make -j2
+
+  build_wxwidgets_osx:
+    name: Build wxWidgets for OSX
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+    - name: Cache wxWidgets
+      uses: actions/cache@v2
+      id: wxwidgets-cache
+      with:
+        path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+    - name: Download wxWidgets
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}
+      run: |
+        wget https://github.com/wxWidgets/wxWidgets/releases/download/v${{ env.WX_WIDGETS_VERSION }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}.tar.bz2
+        tar -xjf wxWidgets-${{ env.WX_WIDGETS_VERSION }}.tar.bz2
+    - name: Build wxwidgets
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+      run: |
+        mkdir build-static
+        cd build-static
+        ../configure --disable-shared --enable-unicode --with-macosx-version-min=10.14
+        make -j2
+
+  build_wxwidgets_windows:
+    name: Build wxWidgets for Windows
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+    - name: Cache wxWidgets
+      uses: actions/cache@v2
+      id: wxwidgets-cache
+      with:
+        path: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+    - name: Install Dependencies
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW32
+        install: >
+          make
+          mingw-w64-i686-gcc
+          unzip
+    - name: Download wxWidgets
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}
+      shell: msys2 {0}
+      run: |
+        mkdir wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        cd wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        wget -q https://github.com/wxWidgets/wxWidgets/releases/download/v${{ env.WX_WIDGETS_VERSION }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}.zip
+        unzip -q wxWidgets-${{ env.WX_WIDGETS_VERSION }}.zip
+        rm wxWidgets-${{ env.WX_WIDGETS_VERSION }}.zip
+    - name: Build wxWidgets
+      if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}\build\msw
+      shell: bash
+      # NOTE: using -j2 appears to cause problems on the MinGW builds
+      run: |
+        mingw32-make -f makefile.gcc SHARED=0 UNICODE=1 BUILD=release clean
+        mingw32-make -f makefile.gcc SHARED=0 UNICODE=1 BUILD=release
+
+  # ############################################################################
+  # The build_<platform> jobs handle building Logo for each platform.
+  #
+  # Linux is run first as it produces the PDF for the other platform builds
+  # to use.
+  # ############################################################################
+
+  build_linux:
+    name: Build Logo for Linux
+    needs: build_wxwidgets_linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - name: Install Dependencies
+      run: >
+        sudo apt-get install
+        autoconf-archive
+        libwxgtk3.0-dev
+        texlive
+        zip
+    - name: wxWidgets Cache
+      uses: actions/cache@v2
+      id: wxwidgets-cache
+      with:
+        path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    - name: Build Logo
+      env:
+        WX_CONFIG_PATH: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}/build-static/wx-config
+      run: |
+        autoreconf --install
+        ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH
+        make -j2 dist
+        make -j2 dist-zip
+    - name: Archive ucblogo.tar.gz
+      uses: actions/upload-artifact@v2
+      with:
+        name: ucblogo.tar.gz
+        path: >
+          *.tar.gz
+    - name: Archive ucblogo.zip
+      uses: actions/upload-artifact@v2
+      with:
+        name: ucblogo.zip
+        path: >
+          *.zip
+    - name: Archive ucblogo.pdf
+      uses: actions/upload-artifact@v2
+      with:
+        name: ucblogo.pdf
+        path: docs/ucblogo.pdf
+
+  build_osx:
+    name: Build Logo for OSX
+    needs: [ build_wxwidgets_osx, build_linux ]
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+    - name: Install Dependencies
+      run: >
+        brew install
+        autoconf-archive
+        automake
+        wxwidgets
+    - name: wxWidgets Cache
+      uses: actions/cache@v2
+      id: wxwidgets-cache
+      with:
+        path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    - name: Download PDF manual
+      uses: actions/download-artifact@v2
+      with:
+        name: ucblogo.pdf
+        path: docs
+    - name: Build Logo
+      env:
+        WX_CONFIG_PATH: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}/build-static/wx-config
+      run: |
+        autoreconf --install
+        ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH
+        make -j2 ucblogo.dmg
+    - name: Archive ucblogo.dmg
+      uses: actions/upload-artifact@v2
+      with:
+        name: ucblogo.dmg
+        path: ucblogo.dmg
+
+  download_inno_windows:
+    name: Download Inno for Windows
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+    - name: Cache inno
+      uses: actions/cache@v2
+      id: inno-cache
+      with:
+        path: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
+        key: ${{ runner.os }}-innosetup-${{ env.INNO_VERSION }}
+    - name: Install Dependencies
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW32
+    - name: Download inno
+      if: steps.inno-cache.outputs.cache-hit != 'true'
+      working-directory: ${{ runner.temp }}
+      shell: msys2 {0}
+      run: |
+        mkdir innosetup-${{ env.INNO_VERSION }}
+        cd innosetup-${{ env.INNO_VERSION }}
+        wget -q https://files.jrsoftware.org/is/6/innosetup-${{ env.INNO_VERSION }}.exe
+
+  build_windows:
+    name: Build Logo for Windows
+    needs: [ download_inno_windows, build_wxwidgets_windows, build_linux ]
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+    - name: Install Dependencies
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW32
+        install: >
+          make
+          mingw-w64-i686-gcc
+    - name: Inno Cache
+      uses: actions/cache@v2
+      id: inno-cache
+      with:
+        path: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
+        key: ${{ runner.os }}-innosetup-${{ env.INNO_VERSION }}
+    - name: Install Inno
+      working-directory: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
+      shell: pwsh
+      run: |
+        ./innosetup-${{ env.INNO_VERSION }}.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
+    - name: wxWidgets Cache
+      uses: actions/cache@v2
+      id: wxwidgets-cache
+      with:
+        path: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    - name: Prepare Repository
+      shell: bash
+      run: |
+        git clean -x -d -f .
+        mingw32-make -f makefile.msys git.c
+        rm libloc.c
+    - name: Download PDF manual
+      uses: actions/download-artifact@v2
+      with:
+        name: ucblogo.pdf
+        path: docs
+    - name: Build Logo
+      shell: bash
+      env:
+        MINGW_BIN_DIR: D:\a\_temp\msys\msys64\mingw32\bin
+        WX_DIR: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+      run: |
+        mingw32-make -f makefile.msys MINGW_BIN_DIR=$MINGW_BIN_DIR WX_DIR=$WX_DIR install_win
+    - name: Run Inno
+      working-directory: ${{ github.workspace }}\inno
+      shell: bash
+      run: |
+        iscc ucblogo.iss
+    - name: Archive installer
+      uses: actions/upload-artifact@v2
+      with:
+        name: ucblogosetup.exe
+        path: inno/ucblogo62setup.exe

--- a/config.h.msys
+++ b/config.h.msys
@@ -1,1 +1,2 @@
 #define RETSIGTYPE void
+#define VERSION "6.2pre"

--- a/inno/ucblogo.iss
+++ b/inno/ucblogo.iss
@@ -9,7 +9,7 @@ AppPublisher=University of California, Berkeley
 AppPublisherURL=http://www.cs.berkeley.edu/~bh/logo.html
 AppSupportURL=https://github.com/jrincayc/ucblogo-code/issues
 AppUpdatesURL=https://github.com/jrincayc/ucblogo-code/releases
-OutputBaseFilename=ucblogo61setup
+OutputBaseFilename=ucblogo62setup
 OutputDir=.
 DefaultDirName={autopf}\UCBLogo
 DefaultGroupName=Berkeley Logo
@@ -41,7 +41,7 @@ Source: "C:\UCBLOGO\lib\logo\HELPFILES\*.*"; DestDir: "{app}\HELPFILE"; CopyMode
 Source: "C:\UCBLOGO\lib\logo\LOGOLIB\*.*"; DestDir: "{app}\LOGOLIB"; CopyMode: alwaysoverwrite; Components: program
 Source: "C:\UCBLOGO\lib\logo\LICENSE"; DestDir: "{app}"; CopyMode: alwaysoverwrite; Components: program
 Source: "C:\UCBLOGO\lib\logo\README.txt"; DestDir: "{app}"; CopyMode: alwaysoverwrite; Components: program
-Source: "C:\UCBLOGO\lib\logo\usermanual.pdf"; DestDir: "{app}\DOCS"; CopyMode: alwaysoverwrite; Components: pdf
+Source: "C:\UCBLOGO\lib\logo\ucblogo.pdf"; DestDir: "{app}\DOCS"; CopyMode: alwaysoverwrite; Components: pdf
 Source: "C:\UCBLOGO\lib\logo\SOURCE\*.*"; DestDir: "{app}\SOURCE"; CopyMode: alwaysoverwrite; Components: source
 
 [Icons]

--- a/makefile.msys
+++ b/makefile.msys
@@ -1,10 +1,12 @@
 CC	= gcc
-CFLAGS	= -g -O -DHAVE_WX    -DX_DISPLAY_MISSING -O0
+CFLAGS	= -g -O -DHAVE_CONFIG_H -DHAVE_WX -DX_DISPLAY_MISSING -O0
 CXX     = g++
-CXXFLAGS =  -DHAVE_WX -I$(HOME)/wxWidgets-3.0.4/include -I$(HOME)/wxWidgets-3.0.4/lib/gcc_lib/mswu -D__WXDEBUG__ -D__WXMSW__ -mthreads
-LDFLAGS	=   -mwindows
-WX_LIB_LOC = $(HOME)/wxWidgets-3.0.4/lib/gcc_lib/
-LIBS  =   -lm  -L/usr/local/lib  -mwindows -mthreads  -mwindows -Wl,--subsystem,windows -mwindows -L$(WX_LIB_LOC)  -lwxmsw30u_richtext -lwxmsw30u_aui -lwxmsw30u_html -lwxmsw30u_adv -lwxmsw30u_core -lwxbase30u_net -lwxbase30u  -lwxregexu -lwxtiff -lwxjpeg -lwxpng -lwxzlib -lrpcrt4 -loleaut32 -lole32 -luuid -lwinspool -lwinmm -lshell32 -lcomctl32 -lcomdlg32 -lctl3d32 -ladvapi32 -lwsock32 -lgdi32
+MINGW_BIN_DIR = /mingw/bin
+WX_DIR = $(HOME)/wxWidgets-3.0.4
+CXXFLAGS =  -DHAVE_CONFIG_H -DHAVE_WX -I$(WX_DIR)/include -I$(WX_DIR)/lib/gcc_lib/mswu -D__WXDEBUG__ -D__WXMSW__ -mthreads
+LDFLAGS	=   -mwindows -static
+WX_LIB_LOC = $(WX_DIR)/lib/gcc_lib/
+LIBS  =   -lm  -L/usr/local/lib  -mwindows -mthreads  -mwindows -Wl,--subsystem,windows -mwindows -L$(WX_LIB_LOC)  -lwxmsw30u_richtext -lwxmsw30u_aui -lwxmsw30u_html -lwxmsw30u_adv -lwxmsw30u_core -lwxbase30u_net -lwxbase30u  -lwxregexu -lwxtiff -lwxjpeg -lwxpng -lwxzlib -lrpcrt4 -loleaut32 -lole32 -luuid -lwinspool -lwinmm -lshell32 -lcomctl32 -lcomdlg32 -ladvapi32 -lwsock32 -lgdi32
 prefix = /c/ucblogo
 BINDIR        = $(prefix)/bin
 LIBLOC        = $(prefix)/lib/logo
@@ -48,10 +50,10 @@ libloc.c:
 	echo 'char *temploc="/tmp";' >> libloc.c
 	echo 'char *separator="/";' >> libloc.c
 
-logolib/Messages:	makelib Messages
-	chmod +x makelib
-	./makelib
-	cp -f Messages logolib
+#logolib/Messages:	makelib Messages
+#	chmod +x makelib
+#	./makelib
+#	cp -f Messages logolib
 
 helpfiles:
 	mkdir helpfiles
@@ -76,14 +78,14 @@ ship:
 install_win: all
 	for d in $(BINDIR) $(LIBLOC) $(LIBLOC)/logolib $(LIBLOC)/helpfiles $(LIBLOC)/csls $(LIBLOC)/source; do [ -d $$d ] || mkdir -p $$d || exit 1; done
 	cp logo.exe $(BINDIR)/ucblogo.exe
-	cp /mingw/bin/libgcc_s_dw2-1.dll /mingw/bin/libstdc++-6.dll $(BINDIR)/
+	cp $(MINGW_BIN_DIR)/libgcc_s_dw2-1.dll $(MINGW_BIN_DIR)/libstdc++-6.dll $(BINDIR)/
 	cp -f logolib/* $(LIBLOC)/logolib/.
 	cp -f helpfiles/* $(LIBLOC)/helpfiles/.
 	cp -f csls/* $(LIBLOC)/csls/.
 	cp -f LICENSE $(LIBLOC)/
 	cp -f README.md $(LIBLOC)/README.txt
-	cp -f *.[ch]* makefile.msys ucblogo.xpm logo_win.rc logologo.ico makelib Messages docs/usermanual.texi $(LIBLOC)/source/
-	cp -f docs/usermanual.pdf $(LIBLOC)/
+	cp -f *.[ch]* makefile.msys ucblogo.xpm logo_win.rc logologo.ico docs/ucblogo.texi $(LIBLOC)/source/
+	cp -f docs/ucblogo.pdf $(LIBLOC)/
 	#(cd docs; prefix=$(prefix) LIBLOC=$(LIBLOC) BINDIR=$(BINDIR) $(MAKE) install)
 #	prefix=$(prefix); LIBLOC=$(LIBLOC); BINDIR=$(BINDIR); export prefix LIBLOC BINDIR; cd emacs; $(MAKE) install
 

--- a/makefile.msys
+++ b/makefile.msys
@@ -4,7 +4,7 @@ CXX     = g++
 MINGW_BIN_DIR = /mingw/bin
 WX_DIR = $(HOME)/wxWidgets-3.0.4
 CXXFLAGS =  -DHAVE_CONFIG_H -DHAVE_WX -I$(WX_DIR)/include -I$(WX_DIR)/lib/gcc_lib/mswu -D__WXDEBUG__ -D__WXMSW__ -mthreads
-LDFLAGS	=   -mwindows -static
+LDFLAGS	=   -mwindows 
 WX_LIB_LOC = $(WX_DIR)/lib/gcc_lib/
 LIBS  =   -lm  -L/usr/local/lib  -mwindows -mthreads  -mwindows -Wl,--subsystem,windows -mwindows -L$(WX_LIB_LOC)  -lwxmsw30u_richtext -lwxmsw30u_aui -lwxmsw30u_html -lwxmsw30u_adv -lwxmsw30u_core -lwxbase30u_net -lwxbase30u  -lwxregexu -lwxtiff -lwxjpeg -lwxpng -lwxzlib -lrpcrt4 -loleaut32 -lole32 -luuid -lwinspool -lwinmm -lshell32 -lcomctl32 -lcomdlg32 -ladvapi32 -lwsock32 -lgdi32
 prefix = /c/ucblogo
@@ -50,11 +50,6 @@ libloc.c:
 	echo 'char *temploc="/tmp";' >> libloc.c
 	echo 'char *separator="/";' >> libloc.c
 
-#logolib/Messages:	makelib Messages
-#	chmod +x makelib
-#	./makelib
-#	cp -f Messages logolib
-
 helpfiles:
 	mkdir helpfiles
 
@@ -78,7 +73,7 @@ ship:
 install_win: all
 	for d in $(BINDIR) $(LIBLOC) $(LIBLOC)/logolib $(LIBLOC)/helpfiles $(LIBLOC)/csls $(LIBLOC)/source; do [ -d $$d ] || mkdir -p $$d || exit 1; done
 	cp logo.exe $(BINDIR)/ucblogo.exe
-	cp $(MINGW_BIN_DIR)/libgcc_s_dw2-1.dll $(MINGW_BIN_DIR)/libstdc++-6.dll $(BINDIR)/
+	cp $(MINGW_BIN_DIR)/libgcc_s_dw2-1.dll $(MINGW_BIN_DIR)/libstdc++-6.dll $(MINGW_BIN_DIR)/libwinpthread-1.dll $(BINDIR)/
 	cp -f logolib/* $(LIBLOC)/logolib/.
 	cp -f helpfiles/* $(LIBLOC)/helpfiles/.
 	cp -f csls/* $(LIBLOC)/csls/.


### PR DESCRIPTION
To set some context- I'm submitting this PR with the thought it may assist in the overall 6.2 release process. If it's more of a disruption at this point, I can close the PR and work on this as a post-6.2 idea (no worries either way :) ).

I've tried to break down the change into three rough categories below; but, am also going to add a few comments in places where I'm particularly uncertain about the changes I made. To get a sense of what it looks like in action:
https://github.com/dmalec/ucblogo-code/actions/runs/430995787

_(You can view the workflow anonymously; but, do need to be logged into GitHub to download the artifacts)_

**CD features:**
* Builds and caches wxWidgets for three target platforms - Linux, OSX, Windows
* Builds on Linux, producing the PDF, source tar.gz, and source .zip
* Builds on OSX and Windows, leveraging the the PDF from the Linux build
* End state should be 5 artifacts - PDF, .tar.gx, .zip, .dmg, .exe

**CD motivated changes:**
* Allow overriding of MinGw bin directory and wxWidgets directory in makefile.msys
* Added -static flag to LDFLAGS in makefile.msys
* Removed -lctl3d32 from LIBS in makefile.msys
* Commented out makelib and Messages build targets in makefile.msys

**6.2 specific changes:**
* Added VERSION to config.h.msys
* Added -DHAVE_CONFIG_H to CFLAGS and CXXFLAGS in makefile.msys
* Updated OutputBaseFilename to ucblogo62setup in inno/ucblogo.iss
* Updated PDF/texi filename from usermanual.* to ucblogo.* in inno/ucblogo.iss and makefile.msys