### PR TITLE
Fix a few errors and warnings in texinfo doc.

### DIFF
--- a/docs/ucblogo.texi
+++ b/docs/ucblogo.texi
@@ -1488,7 +1488,7 @@ in this manual.  So workspace operations such as @code{pots} or
 object.
 
 The initial current object is called @code{logo}; there is an operation
-that outputs that object.  Every object has one or more @var{parents,}
+that outputs that object.  Every object has one or more @var{parents},
 and ultimately the parent of the parent... of an object has to be
 @code{logo}.  The primitive procedures in this manual belong to the
 @code{logo} object, as do global variables.
@@ -1526,7 +1526,7 @@ desired program behavior before they start writing code.  But
 prototyping OOP is the right thing for tinkering, for having a glimmer
 of an idea and playing around with it without a rigid specification.
 So, you want to have dogs in your program.  You start by @var{building a
-dog,} one you can see on the screen as you invent behaviors such as
+dog}, one you can see on the screen as you invent behaviors such as
 @code{roll.over} and @code{wag.tail}.  Then you make a bunch of objects
 with that dog as their parent, using that dog as a prototype.  But the
 prototype dog is still a particular dog, with a particular position,
@@ -1552,6 +1552,11 @@ prototyping OOP language.
 @node    OBJECT CONSTRUCTORS, OBJECT MUTATORS, OBJECTS, OBJECTS
 @section Constructors
 
+@menu
+* KINDOF::
+* SOMETHING::
+* ONEOF::
+@end menu
 
 @node  KINDOF, SOMETHING, OBJECT CONSTRUCTORS, OBJECT CONSTRUCTORS
 @unnumberedsubsec kindof
@@ -2634,7 +2639,7 @@ will be displayed and may be edited until @key{RET} is pressed.
 
 @xref{EOFP} .
 
-@node  CLEARTEXT, SETCURSOR, KEYP, TERMINAL ACCESS
+@node  CLEARTEXT, SETCURSOR, LINEP, TERMINAL ACCESS
 @unnumberedsubsec cleartext
 @cindex cleartext
 @cindex ct


### PR DESCRIPTION
I can retarget to _release_6_2_work_ if that makes more sense or leave as _master_.

Changes:

* Updated `CLEARTEXT` node for new `LINEP` node
* Updated `OBJECT CONSTRUCTORS` node with menu items for `ONEOF`, `SOMETHING`, `KINDOF`
* Moved commas just outside of `@var` tags in object text

Relevant warnings/errors:
```
ucblogo.texi:1491: warning: unlikely character , in @var.
ucblogo.texi:1529: warning: unlikely character , in @var.
ucblogo.texi:5461: warning: unlikely character ( in @var.
ucblogo.texi:5461: warning: unlikely character ) in @var.
ucblogo.texi:5476: warning: unlikely character ( in @var.
ucblogo.texi:5476: warning: unlikely character ) in @var.
ucblogo.texi:5563: warning: unlikely character ( in @var.
ucblogo.texi:5563: warning: unlikely character ) in @var.
ucblogo.texi:5810: warning: unlikely character ( in @var.
ucblogo.texi:5810: warning: unlikely character ) in @var.
ucblogo.texi:5824: warning: unlikely character ( in @var.
ucblogo.texi:5824: warning: unlikely character ) in @var.
ucblogo.texi:2637: Prev field of node `CLEARTEXT' not pointed to.
ucblogo.texi:2598: This node (KEYP) has the bad Next.
ucblogo.texi:2620: Next field of node `LINEP' not pointed to (perhaps incorrect sectioning?).
ucblogo.texi:2637: This node (CLEARTEXT) has the bad Prev.
ucblogo.texi:1552: Node `OBJECT CONSTRUCTORS' lacks menu item for `ONEOF' despite being its Up target.
ucblogo.texi:1552: Node `OBJECT CONSTRUCTORS' lacks menu item for `SOMETHING' despite being its Up target.
ucblogo.texi:1552: Node `OBJECT CONSTRUCTORS' lacks menu item for `KINDOF' despite being its Up target.
```
The parens look to be OK / following the intent of `@var` (and would require a less mechanical set of changes)