### PR TITLE
ISSUE-40: Fix some issues around color palettes.

### DIFF
--- a/graphics.c
+++ b/graphics.c
@@ -1097,10 +1097,14 @@ NODE *lsetpencolor(NODE *arg) {
 	if (is_list(car(arg))) {
 	    val = make_intnode(PEN_COLOR_OFFSET);
 	    lsetpalette(cons(val,arg));
-	} else
+	} else {
 	    val = pos_int_arg(arg);
-	set_pen_color(getint(val));
-	save_color();
+	}
+
+	if (NOT_THROWING) {
+	    set_pen_color(getint(val));
+	    save_color();
+	}
 	done_drawing;
     }
     return(UNBOUND);
@@ -1119,9 +1123,13 @@ NODE *lsetbackground(NODE *arg) {
 	if (is_list(car(arg))) {
 	    val = make_intnode(BACKGROUND_COLOR_OFFSET);
 	    lsetpalette(cons(val,arg));
-	} else
+	} else {
 	    val = pos_int_arg(arg);
-	set_back_ground(getint(val));
+	}
+
+	if (NOT_THROWING) {
+	    set_back_ground(getint(val));
+	}
 	done_drawing;
     }
     return(UNBOUND);
@@ -1483,7 +1491,7 @@ NODE *lfilled(NODE *args) {
     } else
 	val = pos_int_arg(args);
     done_drawing;
-    color = getint(val);
+    color = getint(val) % NUMCOLORS;
 
     old_refresh = refresh_p;
     refresh_p = 1;  /* have to save polygon to fill it */

--- a/wxTurtleGraphics.h
+++ b/wxTurtleGraphics.h
@@ -24,7 +24,7 @@ struct line {
 	short int x2;
 	short int y2;
 	short int pw;
-	unsigned char color;
+	short int color;
 	unsigned char pm;
 	int vis;
 };


### PR DESCRIPTION
Resolves #40 

# Summary
* When `FILLED colornumber` is invoked, make sure the `colornumber` is constrained to the range (original bug)
* Use a signed type for line color so that `SETPENCOLOR rgblist` works as expected (This should fix the bug outlined here: https://sourceforge.net/p/ucblogo/bugs/25/)
* If `SETPENCOLOR` is invoked with a value that produces an error (E.G. negative `colornumber`) don't change anything
* If `SETBACKGROUND` is invoked with a value that produces an error (E.G. negative `colornumber`) don't change anything

# Details
The change for `FILLED colornumber` is the one proposed by @zigggit in the bug description. This fixes the reported crashing issue and does not appear to introduce any new issues.

**Test Code**
```
filled -1 [fd 100 rt 90 fd 100]
filled 5 [fd 100 rt 90 fd 100]
filled [99 0 0] [fd 100 rt 90 fd 100]
filled 999999999 [fd 100 rt 90 fd 100]
filled 0 [fd 100 rt 90 fd 100]
```

**Output**
![Screen Shot 2021-01-03 at 12 37 55 PM](https://user-images.githubusercontent.com/330202/103487260-11adb600-4dd2-11eb-878c-d585b92101b6.png)

---

The change for `SETPENCOLOR rgblist` is to update the line data structure to use a signed type instead of an unsigned type in order to preserve the special negative index color entries.

**Test code**
```
setpencolor [100 0 0] fd 100 rt 90
setpencolor [0 100 0] fd 100 rt 90
setpencolor [0 0 100] fd 100 rt 90 
```

**Before**
![Screen Shot 2021-01-03 at 2 51 18 PM](https://user-images.githubusercontent.com/330202/103487411-2fc7e600-4dd3-11eb-94f5-615ecbadaf71.png)

**After**
![Screen Shot 2021-01-03 at 2 46 59 PM](https://user-images.githubusercontent.com/330202/103487340-9ef10a80-4dd2-11eb-8b77-bb14275f4304.png)

---

The last two changes are things I bumped into during testing. `SETPENCOLOR` and `SETBACKGROUND` were showing an error message when given a negative number; but, nonetheless changed the color values.

# Test Environments
OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1909) w/ wxWidgets 3.0.5