### PR TITLE
ISSUE-89: Don't pass a negative index to SetStyle

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -64,7 +64,9 @@ void TextEditor::SetThisFont(wxCommandEvent& event) {
 	SetDefaultStyle(wxTextAttr(TurtleCanvas::colors[wxTerminal::terminal->m_curFG],
 				   TurtleCanvas::colors[wxTerminal::terminal->m_curBG], this->font));
 	if(this->IsShown()){
-		SetStyle(GetLastPosition()-1, GetLastPosition(),
+		wxTextPos lastPosition = GetLastPosition();
+
+		SetStyle(lastPosition > 0 ? lastPosition - 1 : 0, lastPosition,
 			 wxTextAttr(TurtleCanvas::colors[wxTerminal::terminal->m_curFG],
 				    TurtleCanvas::colors[wxTerminal::terminal->m_curBG],this->font));
 	    SetBackgroundColour(


### PR DESCRIPTION
Resolves #89 
Resolves #33 

# Summary
Added a bounds check so that `TextEditor` doesn't attempt to `SetStyle` using a negative starting index.

**OSX**
The root cause of #89 seems to be:
1. Running `EDALL` invokes `TextEditor::Load` which calls `LoadFile` on an empty temp file.
2. As part of the call sequence, this triggers an event.
3. Due to `EVT_TEXT(wxID_ANY, TextEditor::SetThisFont)`, this calls `TextEditor::SetThisFont`.
4. Since the file is empty, `GetLastPosition()-1` is `-1` and the application crashes.

**Linux**
There doesn't seem to be an issue with the initial empty edit; but, deleting the last character in the editor results in the error message discussed in #33.

**Windows**
Appears to be OK with both the previous negative index and the new zero index.

# Test Environments
OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1909) w/ wxWidgets 3.0.5