### PR TITLE
ISSUE-31: Support external editors in wxWidgets builds.

### DIFF
--- a/init.c
+++ b/init.c
@@ -561,7 +561,9 @@ nosugar:
 	helpfiles = getenv("LOGOHELP");
 	csls = getenv("CSLS");
     }
+#ifndef HAVE_WX
     editor = getenv("EDITOR");
+#endif /* HAVE_WX */
 #ifdef WIN32
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, "Software", 0,
 		     KEY_READ, &regKey1) == ERROR_SUCCESS) {
@@ -597,6 +599,7 @@ nosugar:
 			strcpy(csls, buf);
 		    }
 		}
+#ifndef HAVE_WX
 	/*	editor = getenv("EDITOR"); */
 		if (editor == NULL) {
 		    bufsiz=200;
@@ -606,6 +609,7 @@ nosugar:
 			strcpy(editor, buf);
 		    }
 		}
+#endif /* HAVE_WX */
 		RegCloseKey(regKey3);
 	    }
 	    RegCloseKey(regKey2);
@@ -646,6 +650,7 @@ nosugar:
 			strcpy(csls, buf);
 		    }
 		}
+#ifndef HAVE_WX
 	/*	editor = getenv("EDITOR"); */
 		if (editor == NULL) {
 		    bufsiz=200;
@@ -655,6 +660,7 @@ nosugar:
 			strcpy(editor, buf);
 		    }
 		}
+#endif /* HAVE_WX */
 		RegCloseKey(regKey3);
 	    }
 	    RegCloseKey(regKey2);
@@ -711,12 +717,16 @@ nosugar:
 		helpfiles = newhelp;
 #endif
 #endif
-	
+
+#ifdef HAVE_WX
+    if (editor == NULL) editor = "";
+#else
 #ifdef unix
     if (editor == NULL) editor = "emacs";
 #else
     if (editor == NULL) editor = "jove";
-#endif
+#endif /* unix */
+#endif /* HAVE_WX */
     editorname = strrchr(editor, (int)'/');
     if (editorname == NULL) editorname = strrchr(editor, (int)'\\');
 #ifdef WIN32

--- a/wrksp.c
+++ b/wrksp.c
@@ -39,6 +39,7 @@
 
 #ifdef  HAVE_WX
 int wxEditFile(char *);
+long wxLaunchExternalEditor(char *, char *);
 #endif
 
 #ifdef HAVE_UNISTD_H
@@ -1597,6 +1598,9 @@ NODE *ledit(NODE *args) {
 #ifdef __RZTC__
     BOOLEAN was_graphics;
 #endif
+#ifdef HAVE_WX
+    BOOLEAN use_internal_editor = (editor == NULL || strlen(editor) < 1 || strncmp("jove", editor, 4) == 0);
+#endif
     NODE *tmp_line = NIL, *exec_list = NIL;
 
     if (tmp_filename[0] == '\0' || args != NIL) {
@@ -1607,11 +1611,11 @@ NODE *ledit(NODE *args) {
 #endif
     }
 #ifdef HAVE_WX
-	if(!isEditFile){
+	if (!isEditFile && use_internal_editor) {
 		setTermInfo(EDIT_STATE,DO_LOAD);
 	}
 	isEditFile=0;
-#endif
+#endif /* HAVE_WX */
 
     if (args != NIL) {
 	holdstrm = writestream;
@@ -1631,10 +1635,24 @@ NODE *ledit(NODE *args) {
 #ifdef mac
     if (!mac_edit()) return(UNBOUND);
 #else	    /* !mac */
-#ifdef  HAVE_WX
-	doSave = wxEditFile(tmp_filename);
-    if(!doSave || getTermInfo(EDIT_STATE) != DO_LOAD)
-	return(UNBOUND);
+#ifdef HAVE_WX
+    if (use_internal_editor) {
+        doSave = wxEditFile(tmp_filename);
+        if(!doSave || getTermInfo(EDIT_STATE) != DO_LOAD)
+            return(UNBOUND);
+    } else {
+        if (0 != wxLaunchExternalEditor(editor, tmp_filename)) {
+            size_t err_buf_size = strlen(editor) + 1 + strlen(tmp_filename) + 1;
+            char *err_buf = malloc(err_buf_size);
+
+            memset(err_buf, '\0', err_buf_size);
+            sprintf(err_buf, "%s %s", editor, tmp_filename);
+            err_logo(FILE_ERROR, make_strnode(err_buf, NULL, err_buf_size - 1, STRING, strnzcpy));
+            free(err_buf);
+
+            return(UNBOUND);
+        }
+    }
 #else
 #ifdef ibm
 #ifdef __RZTC__

--- a/wrksp.c
+++ b/wrksp.c
@@ -1599,7 +1599,7 @@ NODE *ledit(NODE *args) {
     BOOLEAN was_graphics;
 #endif
 #ifdef HAVE_WX
-    BOOLEAN use_internal_editor = (editor == NULL || strlen(editor) < 1 || strncmp("jove", editor, 4) == 0);
+    BOOLEAN use_internal_editor = (editor == NULL || strlen(editor) < 1);
 #endif
     NODE *tmp_line = NIL, *exec_list = NIL;
 

--- a/wxMain.cpp
+++ b/wxMain.cpp
@@ -274,3 +274,7 @@ extern "C" const char* wxMacGetHelploc(){
 #endif
 	return 0;
 }
+
+extern "C" long wxLaunchExternalEditor(char *editor, char *filename) {
+  return wxExecute(wxString::Format("%s %s", editor, filename), wxEXEC_SYNC);
+}


### PR DESCRIPTION
Resolves #31 

# Summary
This change should wrap up the last point on #31 by changing _wxWidgets_ based builds so that `SETEDITOR` changes the behavior of `EDIT`. Specifically:
* wxWidgets builds ignore `EDITOR` env var to preserve default existing behavior
* If `SETEDITOR` is used to set an `editor`, wxWidgets builds will attempt to launch that command for `EDIT`
* If things go awry, `EDIT` will show the attempted command as a file error message

# Caveats
* This doesn't attempt to solve any platform specific issues around invoking an external program (E.G. on OSX, it leaves it up to the user to understand which flags are needed for `open` in order to make it behave well as an editor invocation).
* The implementation prioritizes leaving existing behavior as-is over features (E.G. - fully ignoring the `EDITOR` environment variable in `wxWidget` builds).
* Game for changes to the error message and am also willing to update docs if needed

# Test Environments
OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
OSX Catalina (10.15.7) console only
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) console only
Windows 10 Home (1909) w/ wxWidgets 3.0.5

# Tests Run
## All wxWidgets 3.0.5 platforms
Without setting the editor, make sure the _wxWidgets_ editor is still default
```
EDIT "foo
```
Result: Uses _wxWidgets_ editor

Check that returning to the _wxWidgets_ editor is relatively simple for users
```
SETEDITOR "
edit "foo
```
Result: Uses _wxWidgets_ editor

Check that errors provide at least a starting point for investigating
```
SETEDITOR "this.is.not.an.editor
EDIT "foo
```
Result:
```
File system error: this.is.not.an.editor /tmp/logo56851
```

## OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
```
SETEDITOR "|open -enW|
EDIT "foo
```
Result: Uses _TextEdit_

```
SETEDITOR "|open -a emacs -nW|
EDIT "foo
```
Result: Uses _emacs_ (installed via _brew_)


## OSX Catalina 10.15.7 console only
```
EDIT "foo
```
Result: Uses _emacs_

```
SETEDITOR "vi
EDIT "foo
```
Result: Uses _vi_


## Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
```
SETEDITOR "emacs
EDIT "foo
```
Result: Uses _emacs_


## Ubuntu Bionic (18.04.5) console only
```
EDIT "foo
```
Result: Uses _emacs_

```
SETEDITOR "vi
EDIT "foo
```
Result: Uses _vi_


## Windows 10 Home (1909) w/ wxWidgets 3.0.5
```
SETEDITOR "notepad
EDIT "foo
```
Result: Uses _notepad_
