### PR TITLE
ISSUE-54: Fix openupdate file open mode

### DIFF
--- a/docs/ucblogo.texi
+++ b/docs/ucblogo.texi
@@ -2335,7 +2335,7 @@ OPENUPDATE filename
 @end example
 
 command.  Opens the named file for reading and writing.  The read and
-write position is initially set to the end of the old file, if any.
+write position is initially set to the end of the old file.
 Note: each open file has only one position, for both reading and
 writing.  If a file opened for update is both @code{READER} and @code{WRITER} at the
 same time, then @code{SETREADPOS} will also affect @code{WRITEPOS} and vice versa.

--- a/files.c
+++ b/files.c
@@ -272,7 +272,15 @@ NODE *lopenappend(NODE *arg) {
 }
 
 NODE *lopenupdate(NODE *arg) {
-    return(lopen(arg,"a+"));
+    NODE *tmp = lopen(arg,"r+");
+
+    if (NOT_THROWING) {
+        // Move to end of file to align with documentation and
+        // so an immediate write doesn't overwrite existing file contents.
+        fseek((FILE *)file_list->n_obj, 0, SEEK_END);
+    }
+
+    return(tmp);
 }
 
 NODE *lallopen(NODE *args) {


### PR DESCRIPTION
Resolves #54 

# Summary

When opening the file for the `OPENUPDATE` command, switch from using `a+` to `r+` based on documentation found regarding the two modes. One example:

> Opening a file with append mode (a as the first character in the mode argument) shall cause all subsequent writes to the file to be forced to the then current end-of-file, regardless of intervening calls to fseek().

IEEE Std 1003.1-2017 https://pubs.opengroup.org/onlinepubs/9699919799/

Additionally, advance the file pointer to the end of the file prior to returning. This matches the documentation (and I suspect user expectations) that a file open for updating defaults to appending.

# Test Code

## Test 1 - Overwriting

**Test**
```
make "f "TestOverwrite.txt
openwrite :f
setwrite :f
print [this was another test]
close :f
openupdate :f
setwrite :f
setwritepos 2
type "at
setread :f
setreadpos 0
make "a readrawline
close :f
print :a
```

**Result**
File contains:
```
that was another test
```

## Test 2 - Appending

**Test**
```
make "f "TestAppend.txt
openwrite :f
setwrite :f
print [this was another test]
close :f
openupdate :f
setwrite :f
print [that was another test]
close :f
```

**Result**
File contains:
```
this was another test
that was another test
```

# Test Environments

OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1909) w/ wxWidgets 3.0.5