### PR TITLE
ISSUE-95: Remove special case for short waits to prevent system locking

### DIFF
--- a/wxMain.cpp
+++ b/wxMain.cpp
@@ -93,11 +93,8 @@ extern "C" void wxLogoSleep(unsigned int milli) {
   wxDateTime stop_waiting = wxDateTime::UNow() + wxTimeSpan(0,0,0,milli);
   flushFile(stdout);
   extern void wx_refresh();
+
   wx_refresh();
-  if(milli <= 100) {
-    wxMilliSleep(milli);
-    return;
-  }
   while(wxDateTime::UNow().IsEarlierThan(stop_waiting)) {
     if(check_wx_stop(1, 0) || eval_buttonact) {  //force yielding
       break;


### PR DESCRIPTION
Resolves #95 

# Summary

Removed an optimization of short sleep durations which looks like it is preventing event processing / TTY updates.

# Testing

The code snippet in the issue:
```
repeat 100 [print "x wait 1]
```
behaves slightly differently on Windows vs OSX/Linux

On Windows, the `wait` and `print` are interleaved; but, the UI locks up for the duration (E.G. it is not possible to issue a *stop* command via the menu)

On OSX and Linux, the behavior is as described; `print` does not display until the cumulative `wait` time has elapsed. Additionally, the behavior on Windows is also exhibited - the UI goes unresponsive for the cumulative `wait` time.

# Investigation

It looks like this can be replicated for any `wait` from `1` to `6` inclusive. Durations of `7` and above seem to work as expected, with the UI being responsive and output being interleaved. This `6` seems to line up with nicely the `6` in `lwait`: https://github.com/jrincayc/ucblogo-code/blob/8d03f497146e641d7c3785ab2562b5148584fb3d/coms.c#L442-L443

Which then lines up with an optimization in `wxLogoSleep`:

https://github.com/jrincayc/ucblogo-code/blob/a39a24c447ac16222a0eee368a428186ba6424fa/wxMain.cpp#L97-L100

Removing that optimization appears to fix the issue without introducing new issues. That said, I'm unsure if the optimization was introduced to address cases I'm not testing against.

# Test Environments

OSX Catalina 10.15.7 w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1909) w/ wxWidgets 3.0.5