### PR TITLE
ISSUE-97: Balance calls to setjmp/longjmp regardless of wxWidgets

### DIFF
--- a/files.c
+++ b/files.c
@@ -593,6 +593,10 @@ NODE *lreadchar(NODE *args) {
     }
     charmode_on();
     input_blocking++;
+#ifndef TIOCSTI
+    if (!setjmp(iblk_buf))
+#endif
+    {
 #ifdef HAVE_WX
 	if (interactive && readstream==stdin) {
 	    reading_char_now = 1;
@@ -602,10 +606,6 @@ NODE *lreadchar(NODE *args) {
 	else
 	    c = (char)sysGetC(readstream);
 #else
-#ifndef TIOCSTI
-    if (!setjmp(iblk_buf))
-#endif
-    {
 #ifdef mac
 	csetmode(C_RAW, stdin);
 	while ((c = (char)sysGetC(readstream)) == EOF && readstream == stdin);
@@ -650,8 +650,8 @@ NODE *lreadchar(NODE *args) {
 	c = (char)sysGetC(readstream);
 #endif /* ibm */
 #endif /* mac */
-    }
 #endif /* wx */
+    }
     input_blocking = 0;
 #ifdef HAVE_WX
     if ((!interactive || readstream!=stdin) && feof(readstream)) {


### PR DESCRIPTION
Resolves #97 

# Summary

The root cause of the crash appears to be a `longjmp` in `unblock_input`:
https://github.com/jrincayc/ucblogo-code/blob/33bc65673ca25089c9acaf8a9eb44bb780686105/main.c#L77-L81

which does not have a corresponding `setjmp`. Working hypothesis is that this results in the value of `iblk_buf` being invalid for the current stack resulting in a crash.

Changing `lreadchar` to call `setjmp` even in *wxWidgets* builds appears to solve the problem.

# Testing

As well as testing with the case in the original issue, I was able to reproduce the crashing behavior on the current source build using the following:
```
to outer
  print inner
end

to inner
  output readchar
end
```

Both case were resolved by the moving of `setjmp` and I haven't found any problems this introduces; but, happy to run any tests which might expose them.

# Test Environments

OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
OSX Catalina (10.15.7) console only
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) console only
Windows 10 Home (1909) w/ wxWidgets 3.0.5