### PR TITLE
ISSUE-96: Flush buffer in CURSOR so position isn't dependent on buffer state

### DIFF
--- a/docs/ucblogo.texi
+++ b/docs/ucblogo.texi
@@ -2020,8 +2020,8 @@ request of your program or after an instruction prompt).  This buffering
 makes the program much faster than it would be if each character
 appeared immediately, and in most cases the effect is not disconcerting.
 To accommodate programs that do a lot of positioned text display using
-@code{TYPE}, Logo will force printing whenever @code{SETCURSOR} is invoked.  This
-solves most buffering problems.  Still, on occasion you may find it
+@code{TYPE}, Logo will force printing whenever @code{CURSOR} or @code{SETCURSOR} is
+invoked.  This solves most buffering problems.  Still, on occasion you may find it
 necessary to force the buffered characters to be printed explicitly;
 this can be done using the @code{WAIT} command.  @w{@t{WAIT 0}} will force printing
 without actually waiting.

--- a/helpfiles/type
+++ b/helpfiles/type
@@ -12,9 +12,9 @@ TYPE thing
 	than it would be if each character appeared immediately, and in most
 	cases the effect is not disconcerting.  To accommodate programs that
 	do a lot of positioned text display using TYPE, Logo will force
-	printing whenever SETCURSOR is invoked.  This solves most buffering
-	problems.  Still, on occasion you may find it necessary to force the
-	buffered characters to be printed explicitly; this can be done using
-	the WAIT command.  WAIT 0 will force printing without actually
-	waiting.
+	printing whenever CURSOR or SETCURSOR is invoked.  This solves most
+	buffering problems.  Still, on occasion you may find it necessary to
+	force the buffered characters to be printed explicitly; this can be
+	done using the WAIT command.  WAIT 0 will force printing without
+	actually waiting.
 

--- a/term.c
+++ b/term.c
@@ -262,6 +262,13 @@ NODE *lcleartext(NODE *args) {
 }
 
 NODE *lcursor(NODE *args) {
+
+    // Flush buffer so it doesn't impact cursor position.
+    fflush(stdout);
+#ifdef __RZTC__
+    zflush();
+#endif
+
     return(cons(make_intnode((FIXNUM)(x_coord-x_margin)),
 		cons(make_intnode((FIXNUM)(y_coord-y_margin)), NIL)));
 }

--- a/usermanual
+++ b/usermanual
@@ -887,11 +887,11 @@ TYPE thing
 	than it would be if each character appeared immediately, and in most
 	cases the effect is not disconcerting.  To accommodate programs that
 	do a lot of positioned text display using TYPE, Logo will force
-	printing whenever SETCURSOR is invoked.  This solves most buffering
-	problems.  Still, on occasion you may find it necessary to force the
-	buffered characters to be printed explicitly; this can be done using
-	the WAIT command.  WAIT 0 will force printing without actually
-	waiting.
+	printing whenever CURSOR or SETCURSOR is invoked.  This solves most
+	buffering problems.  Still, on occasion you may find it necessary to
+	force the buffered characters to be printed explicitly; this can be
+	done using the WAIT command.  WAIT 0 will force printing without
+	actually waiting.
 
 SHOW thing
 (SHOW thing1 thing2 ...)

--- a/wxterm.c
+++ b/wxterm.c
@@ -169,6 +169,10 @@ NODE *lcleartext(NODE *args) {
 
 NODE *lcursor(NODE *args) {
 	int x_coord, y_coord;
+
+	// Flush buffer so it doesn't impact cursor position.
+	flushFile(stdout);
+
 	x_coord=getTermInfo(X_COORD);
 	y_coord=getTermInfo(Y_COORD);
 


### PR DESCRIPTION
Resolves #96 

# Summary

It appears that the root cause of the problem is that `TYPE` is being buffered and so the cursor position is not updated prior to the call to `CURSOR`. Therefore, the cursor keeps getting reset to the same position after updating the display of  *accept* / *reject* status. Flushing the buffer prior to reading the cursor appears to fix this.

A bit torn on this one - on the one hand, it seems like reading the `CURSOR` position should have no side effects. That said, I feel like having the position returned by `CURSOR` dependent on internal buffering is a larger surprise when it happens.

While the non-*wxWidgets* implementation don't display the bug in this case, I did update their version of `lcursor` for consistency and did not see any negative side effects during testing.

# Testing

Ran a variety of strings including a, b, and other characters. The code appears to work as expected.

# Test Environments

OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
OSX Catalina (10.15.7) console only
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) console only
Windows 10 Home (1909) w/ wxWidgets 3.0.5