### PR TITLE
ISSUE-102: changed quit/exit menu constant to wxWidget standard.

### DIFF
--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -150,7 +150,6 @@ enum
 	Menu_File_Print_Text_Prev,
 	Menu_File_Print_Turtle,
 	Menu_File_Print_Turtle_Prev,
-	Menu_File_Quit,
 	
 	Menu_Edit = 300,
     Menu_Edit_Copy,
@@ -334,7 +333,7 @@ EVT_MENU(Menu_File_Print_Text,			LogoFrame::OnPrintText)
 EVT_MENU(Menu_File_Print_Text_Prev,		LogoFrame::OnPrintTextPrev)
 EVT_MENU(Menu_File_Print_Turtle,	TurtleCanvas::PrintTurtleWindow)
 EVT_MENU(Menu_File_Print_Turtle_Prev,   TurtleCanvas::TurtlePrintPreview)
-EVT_MENU(Menu_File_Quit,			LogoFrame::OnQuit)
+EVT_MENU(wxID_EXIT,				LogoFrame::OnQuit)
 EVT_MENU(Menu_Edit_Copy,			LogoFrame::DoCopy)
 EVT_MENU(Menu_Edit_Paste,			LogoFrame::DoPaste)
 EVT_MENU(Menu_Logo_Pause,			LogoFrame::DoPause)
@@ -468,7 +467,7 @@ void LogoFrame::SetUpMenu(){
 	fileMenu->Append( Menu_File_Print_Turtle, _T("Print Turtle Graphics"));
 	fileMenu->Append( Menu_File_Print_Turtle_Prev, _T("Turtle Graphics Print Preview"));
 	fileMenu->AppendSeparator();
-	fileMenu->Append(Menu_File_Quit, _T("Quit UCBLogo \tCtrl-Q"));
+	fileMenu->Append(wxID_EXIT, _T("Quit UCBLogo \tCtrl-Q"));
 	
 	
 	wxMenu *editMenu = new wxMenu;


### PR DESCRIPTION
Resolves #102 

# Summary 

On OSX, wxWidgets can manage the placement of certain menu items to follow the OSX look and feel without changing the behavior on other platforms. The simplest approach seemed to be changing the _Quit_ menu constant from `Menu_File_Quit` to the wxWidget standard of `wxID_EXIT`.

See: https://wiki.wxwidgets.org/WxMac-specific_topics#Special_Menu_Items

# Testing

On OSX, the _Quit_ menu item:
* appears under the _UCBLogo_ application menu
* no longer appears under the _File_ menu
* exits the application
* aligns in location with other OSX applications.

On Windows and Ubuntu, the _Quit_ menu item:
* remains under the _File_ menu as before
* continues to work as expected

# Test Environments
OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5
Windows 10 Home (1909) w/ wxWidgets 3.0.5
