### PR TITLE
Reworked wx terminal command history feature.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,7 +45,7 @@ git.c: FORCE
 
 if WX
 # need C++ linker
-ucblogo_SOURCES += wxMain.cpp wxTerminal.cpp wxTurtleGraphics.cpp
+ucblogo_SOURCES += wxMain.cpp wxTerminal.cpp wxCommandHistory.cpp wxTurtleGraphics.cpp
 ucblogo_SOURCES += TextEditor.cpp
 ucblogo_SOURCES += wxterm.c
 else
@@ -75,7 +75,7 @@ dist_pixmaps_DATA = ucblogo.xpm
 # #include files used in build
 EXTRA_DIST = eval.h globals.h gpl_text.h LogoFrame.h logo.h		\
  nographics.h obj.h TextEditor.h wxGlobals.h wxGraphics.h wxMain.h	\
- wxTerminal.h wxTurtleGraphics.h xgraphics.h
+ wxTerminal.h wxCommandHistory.h wxTurtleGraphics.h xgraphics.h
 
 # Source for utility program for regenerating ./helpfiles/ from ./usermanual
 # See below; needs to run in build environment.

--- a/wxCommandHistory.cpp
+++ b/wxCommandHistory.cpp
@@ -1,0 +1,179 @@
+/*
+ *      wxCommandHistory.cpp      wx logo terminal command history module
+ *
+ *      This program is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License
+ *      along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <cstddef>
+#include <cstring>
+
+#include "wxCommandHistory.h"
+
+char * clone_string_segment(const char *src_string, const int len);
+
+
+wxCommandHistory::wxCommandHistory(const int history_size) {
+  // Set up the buffer for storing commands.
+  m_history_size = history_size;
+
+  m_command_history = new char *[m_history_size];
+  memset(m_command_history, (int)NULL, sizeof(char *) * m_history_size);
+
+  m_history_in_index = m_history_out_index = 0;
+
+  // Set up the scratch space for storing the current working command.
+  m_working_command = NULL;
+
+  m_history_moves = 0;
+}
+
+wxCommandHistory::~wxCommandHistory() {
+  for (int i=0; i<m_history_size; i++) {
+    if (m_command_history[i] != NULL) {
+      delete[] m_command_history[i];
+    }
+  }
+  delete[] m_command_history;
+
+  if (m_working_command != NULL) {
+    delete[] m_working_command;
+  }
+}
+
+void wxCommandHistory::handle_command_entered(const char *input_buffer, const int command_len) {
+
+  // Clear the current working command scratch space.
+  m_history_moves = 0;
+  if (m_working_command != NULL) {
+    delete[] m_working_command;
+    m_working_command = NULL;
+  }
+
+  // Guard against storing empty commands.
+  if (command_len < 1) {
+    return;
+  }
+
+  // Store the command in the history.
+  m_command_history[m_history_in_index] = clone_string_segment(input_buffer, command_len);
+  m_history_in_index++;
+
+  // Handle buffer wraparound.
+  if (m_history_in_index >= m_history_size) {
+    m_history_in_index = 0;
+  }
+
+  // Free up space for the next command if needed.
+  if (m_command_history[m_history_in_index] != NULL) {
+    delete[] m_command_history[m_history_in_index];
+    m_command_history[m_history_in_index] = NULL;
+  }
+
+  // Update the output index.
+  m_history_out_index = m_history_in_index;
+}
+
+char * wxCommandHistory::handle_previous(const char *input_buffer, const int command_len) {
+  maybe_store_working_command(input_buffer, command_len);
+
+  // If at the beginning of history navigation, and a scratch command has been stored, return it.
+  if (m_working_command != NULL && m_history_moves == 0) {
+    m_history_moves++;
+
+    return m_working_command;
+  }
+
+  int old_history_out_index = m_history_out_index;
+
+  m_history_out_index--;
+
+  // Handle buffer wraparound.
+  if (m_history_out_index < 0) {
+    m_history_out_index = m_history_size - 1;
+  }
+
+  if (m_command_history[m_history_out_index] != NULL) {
+    // Return the command from history.
+    m_history_moves++;
+
+    return m_command_history[m_history_out_index];
+  } else {
+    // There is no more history, restore the history out index.
+    m_history_out_index = old_history_out_index;
+
+    return NULL;
+  }
+}
+
+char * wxCommandHistory::handle_next(const char *input_buffer, const int command_len) {
+  maybe_store_working_command(input_buffer, command_len);
+
+  if (m_command_history[m_history_out_index] != NULL) {
+    m_history_out_index++;
+  }
+
+  // Handle buffer wraparound.
+  if (m_history_out_index >= m_history_size) {
+    m_history_out_index = 0;
+  }
+
+  if (m_history_moves > 0) {
+    m_history_moves--;
+  }
+
+  // If at the beginning of history navigation, and a scratch command has been stored, return it.
+  if (m_command_history[m_history_out_index] == NULL) {
+
+    if (m_working_command != NULL && m_history_moves == 1) {
+      return m_working_command;
+    }
+  }
+
+  // Return the command or NULL to signify there are no more commands in history.
+  return m_command_history[m_history_out_index];
+}
+
+void wxCommandHistory::maybe_store_working_command(const char *input_buffer, const int command_len) {
+
+  // Guard against storing empty commands.
+  if (command_len < 1) {
+    return;
+  }
+
+  if (m_history_moves == 0 || (m_history_moves == 1 && m_working_command != NULL)) {
+    // Store the current working command in the command scratch space.
+    if (m_working_command != NULL) {
+      delete[] m_working_command;
+    }
+    m_working_command = clone_string_segment(input_buffer, command_len);
+
+    // Only increment when first saving a working command, leave move count
+    // as-is when updating the command scratch space.
+    if (m_history_moves == 0) {
+      m_history_moves++;
+    }
+  }
+}
+
+char * clone_string_segment(const char *src_string, const int len) {
+  char *cloned_string = new char[len + 1];
+
+  for(int i = 0; i < len; i++) {
+    cloned_string[i] = src_string[i];
+  }
+  cloned_string[len] = '\0';
+
+  return cloned_string;
+}

--- a/wxCommandHistory.h
+++ b/wxCommandHistory.h
@@ -1,0 +1,56 @@
+/*
+ *      wxCommandHistory.h        wx logo terminal command history module
+ *
+ *      This program is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License
+ *      along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef WXCOMMANDHISTORY_H_INCLUDED_
+#define WXCOMMANDHISTORY_H_INCLUDED_
+
+
+class wxCommandHistory {
+
+public:
+  wxCommandHistory(const int history_size);
+  ~wxCommandHistory();
+
+  void handle_command_entered(const char *input_buffer, const int command_len);
+
+  char * handle_previous(const char *input_buffer, const int command_len);
+  char * handle_next(const char *input_buffer, const int command_len);
+
+private:
+  void maybe_store_working_command(const char *input_buffer, const int command_len);
+
+  // Fixed-size circular buffer for storing command history.
+  char **m_command_history;
+
+  // The size of the history buffer (I.E. number of commands to remember).
+  int m_history_size;
+
+  // The index to write in to the command history buffer.
+  int m_history_in_index;
+
+  // The index to read out from the command history buffer.
+  int m_history_out_index;
+
+  // Scratch space to hold working command during history operations.
+  char *m_working_command;
+
+  // The depth of navigation in the command history, including the working command (if present).
+  int m_history_moves;
+};
+
+#endif /* WXCOMMANDHISTORY_H_INCLUDED_ */

--- a/wxTerminal.h
+++ b/wxTerminal.h
@@ -8,6 +8,8 @@
 #include <wx/html/htmprint.h>
 #include <wx/print.h>
 
+#include "wxCommandHistory.h"
+
 #define CURSOR_BLINK_DEFAULT_TIMEOUT	300
 #define CURSOR_BLINK_MAX_TIMEOUT	2000
 #define wxEVT_COMMAND_TERM_RESIZE        wxEVT_USER_FIRST + 1000
@@ -173,6 +175,9 @@ struct wxterm_linepos {
   wxterm_line_buffer *term_lines;
   wxterm_charpos curr_char_pos;
   wxterm_linepos curr_line_pos;
+
+  wxCommandHistory *m_command_history;
+
 public:
   int cursor_x, cursor_y;
 
@@ -290,6 +295,7 @@ public:
   void handle_clear_to_end();
   void handle_history_prev();
   void handle_history_next();
+  void update_command_from_history(const char *);
   void handle_left();
   void handle_right();
 


### PR DESCRIPTION
# Summary
Reading through the wx terminal code, I noticed that a feature had been started to remember the current working command during history operations. This seemed like a good idea - without it, an up arrow or down arrow will cause the loss of anything which is being worked on.

# Details
There are a few things going on with this change:
* Factored out command history into its own class
* Prevent blank lines from being added to the history
* Remember the working command if one is present

I mulled things over a bit before factoring this out into its own class - my thinking here is that breaking up `wxTerminal.cpp` a bit will help with maintainability and adding features over time. Game to talk this one over more if needed.

# Testing

Existing functionality with up arrow / down arrow continues to work as expected. If someone never starts working on a command prior to navigating history, they should not see a difference in behavior.

Completely empty lines no longer get added to history.

Working command is a bit more complex - if you begin to type and then:
* Press down arrow - the command will clear as before; but, up arrow will now restore what you were working on.
* Press up arrow - you will navigate history as before; but you can now down arrow back to the working command.
* If you navigate history to the working command and update it, this will be remembered even if you navigate through other history.

One bit that might cause surprises - if you navigate to a command in history, edit it, navigate away, then navigate back, it will have reverted to the actual history. This matches the existing behavior; but, might be worth mulling over a bit.

# Test Environments
* OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
*  Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5 
* Windows 10 Home (1909) w/ wxWidgets 3.0.5
