### PR TITLE
ISSUE-104: untreeify procedure when text operator is called.

### DIFF
--- a/wrksp.c
+++ b/wrksp.c
@@ -138,8 +138,10 @@ NODE *ltext(NODE *args) {
 	} else if (is_prim(val)) {
 	    err_logo(IS_PRIM,name);
 	    return UNBOUND;
-	} else 
+	} else {
+	    untreeify_proc(val);
 	    return text__procnode(val);
+	}
     }
     return UNBOUND;
 }


### PR DESCRIPTION
Resolves #104 

# Summary 
This avoids an infinite loop on deep copy when the `text` of a procedure is used to define a procedure. The fix is based on @brianharvey 's comment on #104 about needing to untreeify the procedure prior to the deep copy.

The smallest test case I could find which demonstrated the issue is:
```
? define "example [[] [print "first]]
? example
first
? define "example text "example
```
Which led me to placing the untreeify in the `text` procedure.

# Testing
Game to run any additional tests to make sure this doesn't have any unexpected side effects.

The original case
```
? define "example [[] [print "first] [print "last]]
? example
first
last
? define "example lput [print "new] butlast text "example
? example
first
new
```

Defining a new procedure
```
? define "example [[] [print "first] [print "last]]
? example
first
last
? define "example2 lput [print "new] butlast text "example
? example2
first
new
? example
first
last
```

Printing the output of `text`:
```
? define "example [[] [print "first] [print "last]]
? print text "example
[] [print "first] [print "last]
```

# Test Environments
* OSX Catalina (10.15.7)
* Ubuntu Bionic (18.04.5)
* Windows 10 Pro (19043.1083)