### PR TITLE
Adding step in Linux jobs to update packages prior to installing packages

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -103,6 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+    - name: Update Package Info
+      run: |
+        sudo apt-get update
     - name: Install Dependencies
       run: >
         sudo apt-get install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
+    - name: Update Package Info
+      run: |
+        sudo apt-get update
     - name: Install Dependencies
       run: >
         sudo apt-get install


### PR DESCRIPTION
I believe this will address the error on the latest CD build of master:
https://github.com/jrincayc/ucblogo-code/actions/runs/1141287049

Tested on my fork of the repo for both the CI and CD workflows.