### PR TITLE
Fix help pagination when using wxWidgets

### DIFF
--- a/coms.c
+++ b/coms.c
@@ -23,7 +23,6 @@
 #endif
 
 #ifdef HAVE_WX
-#define fgets wx_fgets
 extern int check_wx_stop(int force_yield, int pause_return_value);
 #endif
 
@@ -65,6 +64,10 @@ extern int check_wx_stop(int force_yield, int pause_return_value);
 #include <sys/time.h>
 #else
 #include <time.h>
+#endif
+
+#ifdef HAVE_WX
+#define fgets wx_fgets
 #endif
 
 NODE *make_cont(enum labels cont, NODE *val) {

--- a/wrksp.c
+++ b/wrksp.c
@@ -23,12 +23,6 @@
 #endif
 
 #include <ctype.h>
-
-#ifdef HAVE_WX
-#define fgets wx_fgets
-#endif
-
-#include <ctype.h>
 #ifdef WIN32
 #include <windows.h>
 #endif
@@ -60,6 +54,10 @@ long wxLaunchExternalEditor(char *, char *);
 #ifdef HAVE_SGTTY_H
 #include <sgtty.h>
 #endif
+#endif
+
+#ifdef HAVE_WX
+#define fgets wx_fgets
 #endif
 
 #ifdef OBJECTS


### PR DESCRIPTION
fgets should not be defined until after all includes, otherwise the imported stdio function will be renamed and the help `--more--` prompt will not be read from the wxWidgets window.

Also removes a duplicate include of `ctype.h`