### PR TITLE
ISSUE-117: Correctly rename command files during OSX build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -143,6 +143,8 @@ mac: ucblogo helpfiles/HELPCONTENTS helpfiles/ALL_NAMES
 	cp csls/[a-z]* UCBLogo.app/Contents/Resources/csls
 	cp -r helpfiles UCBLogo.app/Contents/Resources/
 	cp -r logolib UCBLogo.app/Contents/Resources/
+	mv -v UCBLogo.app/Contents/Resources/logolib/RENAME-GRAVE-ACCENT 'UCBLogo.app/Contents/Resources/logolib/`'
+	mv -v UCBLogo.app/Contents/Resources/logolib/RENAME-NUMBER-SIGN 'UCBLogo.app/Contents/Resources/logolib/#'
 	cp logo.icns UCBLogo.app/Contents/Resources/
 	mkdir -p UCBLogo.app/Contents/MacOS/
 	cp ucblogo UCBLogo.app/Contents/MacOS/UCBLogo


### PR DESCRIPTION
Resolves #117 

# Summary

This change is to have the OSX build rename the two special filenames:

- RENAME-GRAVE-ACCENT
- RENAME-NUMBER-SIGN

in `logolib` when building the application.

# Testing

Without this change, the symptoms described in #117 happen on the OSX builds (but not the Windows or Linux builds).  Once the change has been made, the mentioned commands work as expected:
```
? show `[foo baz ,[bf [a b c]] garply ,@[bf [a b c]]]
[foo baz [b c] garply b c]
```
```
? show cascade 5 [lput # ?] []
[1 2 3 4 5]
```

# Test Environments

- OSX Catalina (10.15.7)

# Notes

I'm unsure if there is a cleaner way to approach using the `install-data-hook` in `logolib/Makefile.am`; however, I could not figure out a way to do that.