### PR TITLE
Fix/standardize STANDOUT in wxWidgets builds

### DIFF
--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -1983,22 +1983,23 @@ wxTerminal::DrawText(wxDC& dc, int fg_color, int bg_color, int flags,
     }
 
   int coord_x, coord_y;
+  bool normal_colors = true;
   dc.SetBackgroundMode(wxSOLID);
   dc.SetTextBackground(TurtleCanvas::colors[bg_color]);
   dc.SetTextForeground(TurtleCanvas::colors[fg_color]);
   coord_y = y * m_charHeight; 
   coord_x = x * (m_charWidth);	
 
-  for(unsigned int i = 0; i < str.Length(); i++, coord_x+=m_charWidth){
-    //clear the pixels first
-    //dc.Blit(coord_x, coord_y, m_charWidth, m_charHeight, &dc, coord_x, coord_y, wxCLEAR);
-    dc.DrawText(str.Mid(i, 1), coord_x, coord_y);
-    //	  if(flags & BOLD && m_boldStyle == OVERSTRIKE)
-    //	  dc.DrawText(str, x + 1, y);
-    if(flags & INVERSE) {
-      InvertArea(dc, coord_x, coord_y, m_charWidth, m_charHeight);
-      //	    dc.Blit( coord_x, coord_y, m_charWidth, m_charHeight, &dc, coord_x, coord_y, wxINVERT);
+  for (unsigned int i = 0; i < str.Length(); i++, coord_x+=m_charWidth) {
+    if ((flags & INVERSE) && normal_colors) {
+      dc.SetTextBackground(TurtleCanvas::colors[fg_color]);
+      dc.SetTextForeground(TurtleCanvas::colors[bg_color]);
+    } else if (!(flags & INVERSE) && !normal_colors) {
+      dc.SetTextBackground(TurtleCanvas::colors[bg_color]);
+      dc.SetTextForeground(TurtleCanvas::colors[fg_color]);
     }
+
+    dc.DrawText(str.Mid(i, 1), coord_x, coord_y);
   }
 }
 

--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -1795,9 +1795,22 @@ wxTerminal::InvertArea(wxDC &dc, int t_x, int t_y, int w, int h, bool scrolled_c
     //}
   }
   if (w > 0 && h > 0) {
-#ifndef __WXMAC__
-    dc.Blit( t_x, t_y, w, h, &dc, t_x, t_y, wxINVERT);
-#endif
+    wxRect area_rect(t_x, t_y, w, h);
+    wxBitmap area_src_bitmap = dc.GetAsBitmap(&area_rect);
+    wxImage scratch_image = area_src_bitmap.ConvertToImage();
+
+    for (int y=0; y<h; y++) {
+      for (int x=0; x<w; x++) {
+        unsigned char r = scratch_image.GetRed(x, y);
+        unsigned char g = scratch_image.GetGreen(x, y);
+        unsigned char b = scratch_image.GetBlue(x, y);
+
+        scratch_image.SetRGB(x, y, 255 - r, 255 - g, 255 - b);
+      }
+    }
+
+    wxBitmap scratch_image_bitmap(scratch_image);
+    dc.DrawBitmap(scratch_image_bitmap, t_x, t_y);
   }
 }
 

--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -1795,22 +1795,9 @@ wxTerminal::InvertArea(wxDC &dc, int t_x, int t_y, int w, int h, bool scrolled_c
     //}
   }
   if (w > 0 && h > 0) {
-    wxRect area_rect(t_x, t_y, w, h);
-    wxBitmap area_src_bitmap = dc.GetAsBitmap(&area_rect);
-    wxImage scratch_image = area_src_bitmap.ConvertToImage();
-
-    for (int y=0; y<h; y++) {
-      for (int x=0; x<w; x++) {
-        unsigned char r = scratch_image.GetRed(x, y);
-        unsigned char g = scratch_image.GetGreen(x, y);
-        unsigned char b = scratch_image.GetBlue(x, y);
-
-        scratch_image.SetRGB(x, y, 255 - r, 255 - g, 255 - b);
-      }
-    }
-
-    wxBitmap scratch_image_bitmap(scratch_image);
-    dc.DrawBitmap(scratch_image_bitmap, t_x, t_y);
+#ifndef __WXMAC__
+    dc.Blit( t_x, t_y, w, h, &dc, t_x, t_y, wxINVERT);
+#endif
   }
 }
 

--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -1983,22 +1983,21 @@ wxTerminal::DrawText(wxDC& dc, int fg_color, int bg_color, int flags,
     }
 
   int coord_x, coord_y;
-  bool normal_colors = true;
+  bool normal_colors = !(flags & INVERSE);
+
   dc.SetBackgroundMode(wxSOLID);
-  dc.SetTextBackground(TurtleCanvas::colors[bg_color]);
-  dc.SetTextForeground(TurtleCanvas::colors[fg_color]);
+  if (normal_colors) {
+    dc.SetTextBackground(TurtleCanvas::colors[bg_color]);
+    dc.SetTextForeground(TurtleCanvas::colors[fg_color]);
+  } else {
+    dc.SetTextBackground(TurtleCanvas::colors[fg_color]);
+    dc.SetTextForeground(TurtleCanvas::colors[bg_color]);
+  }
+
   coord_y = y * m_charHeight; 
   coord_x = x * (m_charWidth);	
 
-  for (unsigned int i = 0; i < str.Length(); i++, coord_x+=m_charWidth) {
-    if ((flags & INVERSE) && normal_colors) {
-      dc.SetTextBackground(TurtleCanvas::colors[fg_color]);
-      dc.SetTextForeground(TurtleCanvas::colors[bg_color]);
-    } else if (!(flags & INVERSE) && !normal_colors) {
-      dc.SetTextBackground(TurtleCanvas::colors[bg_color]);
-      dc.SetTextForeground(TurtleCanvas::colors[fg_color]);
-    }
-
+  for (unsigned int i = 0; i < str.Length(); i++, coord_x += m_charWidth) {
     dc.DrawText(str.Mid(i, 1), coord_x, coord_y);
   }
 }


### PR DESCRIPTION
One possible approach to handling inverted text in wxWidgets builds (both `STANDOUT` and text selection highlighting).

This feels like it could potentially be refined, so I'm going to open it as a draft PR to allow for discussion and further experiments.

# Test Environments
* OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
*  Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5 
* Windows 10 Home (1909) w/ wxWidgets 3.0.5