### PR TITLE
Issue 126: Print preview on Windows

### DIFF
--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -289,6 +289,7 @@ void LogoEventManager::ProcessEvents(int force_yield)
     if(force_yield || foo == 0) {
       if(!inside_yield) {
         inside_yield++;
+        m_logoApp->ProcessIdle();
         m_logoApp->Yield(TRUE);
         inside_yield--;
       }
@@ -557,7 +558,7 @@ void LogoFrame::OnLoad(wxCommandEvent& WXUNUSED(event)){
 void LogoFrame::OnPrintText(wxCommandEvent& WXUNUSED(event)){
 	wxHtmlEasyPrinting *htmlPrinter=wxTerminal::terminal->htmlPrinter;
 	if(!htmlPrinter){
-		htmlPrinter = new wxHtmlEasyPrinting();
+		htmlPrinter = new wxHtmlEasyPrinting(_T(""), logoFrame);
 		int fontsizes[] = { 6, 8, 12, 14, 16, 20, 24 };
 		htmlPrinter->SetFonts(_T("Courier"),_T("Courier"), fontsizes);
 	}
@@ -571,7 +572,7 @@ void LogoFrame::OnPrintText(wxCommandEvent& WXUNUSED(event)){
 void LogoFrame::OnPrintTextPrev(wxCommandEvent& WXUNUSED(event)){
 	wxHtmlEasyPrinting *htmlPrinter=wxTerminal::terminal->htmlPrinter;
 	if(!htmlPrinter){
-		htmlPrinter = new wxHtmlEasyPrinting();
+		htmlPrinter = new wxHtmlEasyPrinting(_T(""), logoFrame);
 		int fontsizes[] = { 6, 8, 12, 14, 16, 20, 24 };
 		htmlPrinter->SetFonts(_T("Courier"),_T("Courier"), fontsizes);
 	}

--- a/wxTerminal.cpp
+++ b/wxTerminal.cpp
@@ -2419,20 +2419,19 @@ wxString * wxTerminal::get_text()
   wxString *outputString = new wxString();
   outputString->Clear();
   outputString->Append(_T("<HTML>\n"));
-  outputString->Append(_T("<BODY>\n"));
-  outputString->Append(_T("<FONT SIZE=2>\n"));
+  outputString->Append(_T("<BODY FONTSIZE='2'>\n"));
+  // The extra BR tag is needed to have the spacing between the first and second lines
+  // the same as the remaining lines.
+  outputString->Append(wxT("<CODE><BR>\n"));
+
   wxString txt = GetChars(0,0,x_max,y_max);
   txt.Replace(_T("\n"),_T("<BR>\n"));
+  txt.Replace(" ", "&nbsp;");
+
   outputString->Append(txt);
-  /*
-  wxterm_linepos tlpos = term_lines;
-  for(i=0;i<ymax;i++){
-    outputString->append(textString->Mid(linenumbers[i]*MAXWIDTH),MAXWIDTH);
-    outputString->append(_T("<BR>"));		
-    }*/
-  outputString->Append(_T("<\\FONT>"));
-  outputString->Append(_T("<\\BODY>"));
-  outputString->Append(_T("<\\HTML>"));
+  outputString->Append(_T("</CODE>"));
+  outputString->Append(_T("</BODY>"));
+  outputString->Append(_T("</HTML>"));
   //  delete textString;
   return outputString;
 }

--- a/wxTurtleGraphics.cpp
+++ b/wxTurtleGraphics.cpp
@@ -822,7 +822,7 @@ void TurtleCanvas::TurtlePrintPreview(wxCommandEvent& WXUNUSED(event)) {
         return;
     }
     preview->SetZoom(100);
-    wxPreviewFrame *frame = new wxPreviewFrame(preview, wxTerminal::terminal->terminal, _T("Turtle Graphics Preview"), wxPoint(100, 100), wxSize(600, 650));
+    wxPreviewFrame *frame = new wxPreviewFrame(preview, logoFrame, _T("Turtle Graphics Preview"), wxPoint(100, 100), wxSize(600, 650));
     frame->Centre(wxBOTH);
     frame->Initialize();
     frame->Show();


### PR DESCRIPTION
Resolves #126

# Summary

This was an interesting bug as there were a few challenges in getting print preview to work on Windows which are Windows specific:

1. The problem that was originally reported seems to be caused by not passing a parent frame to the `wxHtmlEasyPrinting` constructor.
2. With that resolved, the preview was blank and I noticed the turtle graphics preview was also blank. Allowing the event loop to also process idle events appears to resolve this.
3. After a turtle graphics preview (even prior to this change), the key event handling doesn't seem to be properly restored to the terminal. This appears to be resolved by using the logo frame as the parent of the turtle graphics preview.

The final challenge is that the way the text is passed in to the preview appears to cause some rendering problems for all platforms. In the case of Windows, it's particularly dramatic:

![Screen Shot 2022-06-18 at 12 32 50 PM](https://user-images.githubusercontent.com/330202/174452652-ce954023-b161-4cb0-af1a-e0fa1f5c0096.png)

On Linux and OSX, it seems to be limited to spacing problems:
![Screen Shot 2022-06-18 at 2 30 41 PM](https://user-images.githubusercontent.com/330202/174452682-120e7eb3-5b69-4d71-b8f8-f387f6398f8d.png)

This was resolved by fixing the closing tags on the HTML and replacing space characters with `&nbsp;`:
![Screen Shot 2022-06-18 at 3 01 04 PM](https://user-images.githubusercontent.com/330202/174452767-91b6b7cf-ef03-4ebc-b081-b29120c9386e.png)


# Test Environments

OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5 
Windows 10 Pro (19043.1766) w/ wxWidgets 3.0.5
