### PR TITLE
ISSUE-129: Remove obsolete macros from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
 AC_INIT([ucblogo],[6.2.2],[],[],[https://github.com/jrincayc/ucblogo-code])
 AC_CONFIG_SRCDIR([logodata.c])
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 AM_INIT_AUTOMAKE([subdir-objects foreign -Wall])
 
@@ -97,7 +97,6 @@ AM_COND_IF([X11],
  [AC_SEARCH_LIBS(XOpenDisplay, [X11])])
 
 dnl Checks for header files.
-AC_HEADER_STDC
 AC_CHECK_HEADERS([unistd.h string.h])
 AM_COND_IF([WX],,
  [AC_CHECK_HEADERS([sgtty.h termio.h termcap.h termlib.h curses.h])])


### PR DESCRIPTION
Resolves #129 

* AC_CONFIG_HEADER - this is an obsolete synonym for AC_CONFIG_HEADERS.
  https://www.gnu.org/software/automake/manual/1.12/html_node/Obsolete-Macros.html

* AC_HEADER_STDC - this is an obsolete macro, autoconf recommends handling old systems with missing string functions on a case-by-case basis instead of using this macro.
  https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Particular-Headers.html

# Test Environments
* OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
* Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5 