### PR TITLE
ISSUE-50: Indicate correct error line when GOTO has a nonexistent tag

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1391,6 +1391,8 @@ withobject_followup:
 
 goto_continuation:
     if (NOT_THROWING) {
+	NODE *goto_command_line = this_line;
+
 	if (ufun == NIL) {
 	    err_logo(AT_TOPLEVEL, theName(Name_goto));
 	    val = UNBOUND;
@@ -1413,6 +1415,9 @@ goto_continuation:
 		goto fetch_cont;
 	    }
 	}
+
+	// goto tag could not be found
+	this_line = goto_command_line;
 	err_logo(BAD_DATA_UNREC, val);
     }
     val = UNBOUND;


### PR DESCRIPTION
resolves #50 

# Summary
Logo scans to the end of the procedure before raising the error that a `GOTO` references a nonexistent tag. This change:

1. Saves the value of the current line prior to running the code looking for the tag.
2. If the tag is not found, it restores the current line prior to printing an error message.

# Test Environment

* OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
* Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5 
* Windows 10 Pro (19043.1766) w/ wxWidgets 3.0.5