### PR TITLE
ISSUE-20: Resolving warnings about discarding const qualifier on assignment.

### DIFF
--- a/init.c
+++ b/init.c
@@ -698,23 +698,30 @@ nosugar:
     }
 #ifndef __WXMSW__
 	// have to do this because we don't have __WXMAC__ in C
+	// if we might be running on a Mac, call C++ functions that will return
+	// an appropriate path if __WXMAC__ is defined and 0 otherwise.
+
 	const char* wxMacGetCslsloc();
 	const char* wxMacGetHelploc();
 	const char* wxMacGetLibloc();
 	const char* newlib;
 	const char* newcsls;
 	const char* newhelp;
-	// check if we are running wxMac
+
 	newlib = wxMacGetLibloc();
-	if(newlib)
-		logolib = newlib; 
-        //if (helpfiles == NULL) helpfiles = wxMacGetHelploc();
-                newcsls = wxMacGetCslsloc();
-	if(newcsls)
-		csls = newcsls;
+	if (newlib) {
+	  logolib = (char *)newlib;
+	}
+
+	newcsls = wxMacGetCslsloc();
+	if (newcsls) {
+	  csls = (char *)newcsls;
+	}
+
 	newhelp = wxMacGetHelploc();
-        if(newhelp)
-		helpfiles = newhelp;
+	if (newhelp) {
+	  helpfiles = (char *)newhelp;
+	}
 #endif
 #endif
 


### PR DESCRIPTION
# Summary

Resolves the following three warnings:
```
init.c:710:11: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
                logolib = newlib;
                        ^ ~~~~~~

init.c:714:8: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
                csls = newcsls;
                     ^ ~~~~~~~

init.c:717:13: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
                helpfiles = newhelp;
                          ^ ~~~~~~~
```

# Testing

Tested that `HELP` can load helpfiles:
```
? HELP "name
NAME value varname                                      (library procedure)

        command.  Same as MAKE but with the inputs in reverse order.
```

Tested that library procedures can be called:
```
? NAME 5 "foo
? PRINT :foo
5
```

Tested that CSLS files can be loaded:
```
? CSLSLOAD "basic
? BASIC

READY

10 PRINT "HELLO"

READY

20 PRINT "WORLD"

READY

RUN
HELLO
WORLD

READY
```

# Test Environments
* OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
* Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5 
* Windows 10 Pro (19045.2364) w/ wxWidgets 3.0.5
