### PR TITLE
ISSUE-143: Update CI/CD actions from v2 to v3.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Cache wxWidgets
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Cache wxWidgets
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -114,7 +114,7 @@ jobs:
         texlive
         zip
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Build Logo
@@ -124,19 +124,19 @@ jobs:
         make -j2 dist
         make -j2 dist-zip
     - name: Archive ucblogo.tar.gz
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ucblogo.tar.gz
         path: >
           *.tar.gz
     - name: Archive ucblogo.zip
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ucblogo.zip
         path: >
           *.zip
     - name: Archive ucblogo.pdf
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ucblogo.pdf
         path: docs/ucblogo.pdf
@@ -154,17 +154,17 @@ jobs:
         automake
         wxwidgets
     - name: wxWidgets Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
         key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Download PDF manual
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ucblogo.pdf
         path: docs
@@ -176,7 +176,7 @@ jobs:
         ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH
         make -j2 ucblogo.dmg
     - name: Archive ucblogo.dmg
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ucblogo.dmg
         path: ucblogo.dmg
@@ -187,7 +187,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Cache inno
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: inno-cache
       with:
         path: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
@@ -221,7 +221,7 @@ jobs:
           mingw-w64-i686-toolchain
           unzip
     - name: Inno Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: inno-cache
       with:
         path: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
@@ -232,13 +232,13 @@ jobs:
       run: |
         ./innosetup-${{ env.INNO_VERSION }}.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
     - name: wxWidgets Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
         key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Prepare Repository
@@ -248,7 +248,7 @@ jobs:
         mingw32-make -f makefile.msys git.c
         rm libloc.c
     - name: Download PDF manual
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ucblogo.pdf
         path: docs
@@ -268,7 +268,7 @@ jobs:
       run: |
         iscc ucblogo.iss
     - name: Archive installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ucblogosetup.exe
-        path: inno/ucblogo62setup.exe
+        path: inno/ucblogo*setup.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Update Package Info
       run: |
         sudo apt-get update
@@ -51,7 +51,7 @@ jobs:
         awk "/\.\.\./ && ! /Ok$/{exit 1}" logo-unit-test-results.txt	
     - name: Archive Test Results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Logo Unit Test Results
         path: logo-unit-test-results.txt


### PR DESCRIPTION
Closes #143 

Fixes the following warning during CI/CD:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2
```


Fixes the following warning during CI/CD:
```
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```


Fixes issue with CD archiving of Windows installer being sensitive to versions by wildcarding the path:
```
        path: inno/ucblogo62setup.exe**
```
changes to:
```
        path: inno/ucblogo*setup.exe
```