### PR TITLE
ISSUE-138: Rename special character commands during Windows build

### DIFF
--- a/makefile.msys
+++ b/makefile.msys
@@ -77,6 +77,8 @@ install_win: all
 	cp logo.exe $(BINDIR)/ucblogo.exe
 	cp $(MINGW_BIN_DIR)/libgcc_s_dw2-1.dll $(MINGW_BIN_DIR)/libstdc++-6.dll $(MINGW_BIN_DIR)/libwinpthread-1.dll $(BINDIR)/
 	cp -f logolib/* $(LIBLOC)/logolib/.
+	mv -v $(LIBLOC)/logolib/RENAME-GRAVE-ACCENT '$(LIBLOC)/logolib/`'
+	mv -v $(LIBLOC)/logolib/RENAME-NUMBER-SIGN '$(LIBLOC)/logolib/#'
 	cp -f helpfiles/* $(LIBLOC)/helpfiles/.
 	cp -f csls/* $(LIBLOC)/csls/.
 	cp -f LICENSE $(LIBLOC)/


### PR DESCRIPTION
Resolves #138 

# Summary

The Windows build was not renaming the two special character library procedures from:
* RENAME-GRAVE-ACCENT
* RENAME-NUMBER-SIGN

to
*  `` ` ``
*  `#`

This change renames the files during the install so the renamed files can be picked up by inno for packaging.


# Testing

Without this change, the two commands do not work under Windows (given a clean install of 6.2.2 or a clean install of ucblogo623RCsetup.exe ):
```
? repeat 5 [ print # ]
I don't know how  to #


? print first (cascade 4 "bf [The Continuing Story of Bungalow Bill])
I don't know how  to `  in cascade
[if numberp :cascade.limit [if lessp :cascade.limit 0 [(throw "error (se [cascade doesn't like] :cascade.limit [as input] ))] make "cascade.limit ` [greaterp :template.number , [int :cascade.limit]]]]
```

After the change, the two commands work (given a clean install from the new build):
```
? repeat 5 [ print # ]
1
2
3
4
5


? print first (cascade 4 "bf [The Continuing Story of Bungalow Bill])
Bungalow
```

# Test Environments 
* Windows 10 Pro (19045.2364) w/ wxWidgets 3.0.5
