### PR TITLE
Fix OSX CD build

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,6 +10,7 @@ on:
 env:
   INNO_VERSION: 6.1.2
   WX_WIDGETS_VERSION: 3.0.5
+  TARGET_OSX_VERSION: 10.14
 
 jobs:
 
@@ -43,7 +44,7 @@ jobs:
       run: |
         mkdir build-static
         cd build-static
-        ../configure --disable-shared --enable-unicode --with-macosx-version-min=10.14
+        ../configure --disable-shared --enable-unicode --with-macosx-version-min=${{ env.TARGET_OSX_VERSION }}
         make -j2
 
   build_wxwidgets_windows:
@@ -176,6 +177,10 @@ jobs:
     - name: Build Logo
       env:
         WX_CONFIG_PATH: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}/build-static/wx-config
+        CFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        CPPFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        CXXFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        LDFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
       run: |
         autoreconf --install
         ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -152,13 +152,18 @@ jobs:
         brew install
         autoconf-archive
         automake
-        wxwidgets
     - name: wxWidgets Cache
       uses: actions/cache@v3
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
         key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+    - name: Install wxwidgets
+      # Install wxwidgets from cache on build machine so autoconf has WX_CONFIG_CHECK
+      working-directory: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+      run: |
+        cd build-static
+        make install
     - name: Checkout Repository
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
The OSX CD build started producing executables which will not run on OSX 10.<x> systems. My working hypothesis is:
1. GitHub has largely moved the _macOS-latest_ build machines to _macOS-12_ already.
2. OSX 12 needs to have `-mmacosx-version-min` set to 10._x_ for compiling and linking in order to produce an executable for 10._x_.
3. This can be done as a side effect of compiling wxWidgets with `--with-macosx-version-min=10.x` and then using that version of wxWidgets macros during configuration of ucblogo.
4. This can also be done by explicitly setting `-mmacosx-version-min=10.x` prior to compiling logo.

This PR includes two changes:
1. Instead of installing wxWidgets via brew, it installs from the cached copy of wxWidgets. This solves a problem where configure was not finding the `WX_CONFIG_CHECK` macro.
2. Explicitly setting the value of `-mmacosx-version-min` prior to compiling logo. This is a bit belt and suspenders; however, it should prevent a change in the way wxWidgets is managed from impacting the compatibility of the executable build.


