### PR TITLE
ISSUE-150: Validate RANDOM range input has the smaller number first

### DIFF
--- a/math.c
+++ b/math.c
@@ -86,7 +86,11 @@ NODE *lrandom(NODE *arg) {
 		val = pos_int_arg(cdr(arg));
 		if (NOT_THROWING) { /* (random 0 9) <=> (random 10) */
 		    range = getint(val);
-		    range = range + 1 - base;
+		    if (range <= base) {
+		        err_logo(BAD_DATA_UNREC, arg);
+		    } else {
+		        range = range + 1 - base;
+		    }
 		}
 	    }
 	}

--- a/tests/UnitTests-Random.lg
+++ b/tests/UnitTests-Random.lg
@@ -17,10 +17,13 @@ InstallSuite [Random Numbers] [Tests.Random.Setup]
 MAKE "Tests.Random [
   ;list tests here
   Tests.Random.RandomNumMonadic
+  Tests.Random.RandomNumMonadicBadInput
   Tests.Random.RandomNumDyadic
- ]
+  Tests.Random.RandomNumDyadicBadInput
+  Tests.Random.RandomNumDyadicBadRange
+]
 
-;; Test Suite setup procedure, main entry 
+;; Test Suite setup procedure, main entry
 ;; point for all tests in this suite
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -47,9 +50,38 @@ to Tests.Random.RandomNumMonadic
   OUTPUT (AND [(Random 1) = 0])
 end
 
+TO Tests.Random.RandomNumMonadicBadInput
+  CATCH "Error [ Random -10 ]
+  LOCALMAKE "err ERROR
+
+  ; Message 7 is "%p doesn't like %s as input"
+  ; for unexpected negative integers
+  OUTPUT (AND [NOT EMPTY? :err]
+              [EQUAL? FIRST :err 7])
+END
+
 to Tests.Random.RandomNumDyadic
   Make "Num3 (Random 3 5)
   OUTPUT (AND [GreaterEqual? :num3 3]
               [LessEqual? :num3 5])
 end
 
+TO Tests.Random.RandomNumDyadicBadInput
+  CATCH "Error [ (Random -10 -5) ]
+  LOCALMAKE "err ERROR
+
+  ; Message 7 is "%p doesn't like %s as input"
+  ; for unexpected negative integers
+  OUTPUT (AND [NOT EMPTY? :err]
+              [EQUAL? FIRST :err 7])
+END
+
+TO Tests.Random.RandomNumDyadicBadRange
+  CATCH "Error [ (Random 10 5) ]
+  LOCALMAKE "err ERROR
+
+  ; Message 4 is "%p doesn't like %s as input"
+  ; for parameter checks handled in procedure logic
+  OUTPUT (AND [NOT EMPTY? :err]
+              [EQUAL? FIRST :err 4])
+END

--- a/tests/UnitTests-Random.lg
+++ b/tests/UnitTests-Random.lg
@@ -19,7 +19,7 @@ MAKE "Tests.Random [
   Tests.Random.RandomNumMonadic
   Tests.Random.RandomNumMonadicBadInput
   Tests.Random.RandomNumDyadic
-  Tests.Random.RandomNumDyadicBadInput
+  Tests.Random.RandomNumDyadicNegative
   Tests.Random.RandomNumDyadicBadRange
 ]
 
@@ -54,10 +54,10 @@ TO Tests.Random.RandomNumMonadicBadInput
   CATCH "Error [ Random -10 ]
   LOCALMAKE "err ERROR
 
-  ; Message 7 is "%p doesn't like %s as input"
+  ; Message 4 is "%p doesn't like %s as input"
   ; for unexpected negative integers
   OUTPUT (AND [NOT EMPTY? :err]
-              [EQUAL? FIRST :err 7])
+              [EQUAL? FIRST :err 4])
 END
 
 to Tests.Random.RandomNumDyadic
@@ -66,14 +66,10 @@ to Tests.Random.RandomNumDyadic
               [LessEqual? :num3 5])
 end
 
-TO Tests.Random.RandomNumDyadicBadInput
-  CATCH "Error [ (Random -10 -5) ]
-  LOCALMAKE "err ERROR
-
-  ; Message 7 is "%p doesn't like %s as input"
-  ; for unexpected negative integers
-  OUTPUT (AND [NOT EMPTY? :err]
-              [EQUAL? FIRST :err 7])
+TO Tests.Random.RandomNumDyadicNegative
+  Make "Num3 (Random -5 -3)
+  OUTPUT (AND [GreaterEqual? :num3 -5]
+              [LessEqual? :num3 -3])
 END
 
 TO Tests.Random.RandomNumDyadicBadRange


### PR DESCRIPTION
Resolves #150 

# Summary

The `RANDOM` procedure does not check if the first parameter is less than the second parameter on the two input form. This change adds an explicit check and errors if the range is out of order based on the description of the procedure in the manual. It also permits `RANDOM` to accept a range including negative numbers.

# Testing

Without this change, passing in a higher number first leads to unexpected results:
```
? PRINT (RANDOM 5 3)
825322468
?
```

After making this change, passing in a higher number will produce an error:
```
? PRINT (RANDOM 5 6)
6

? PRINT (RANDOM 6 5)
RANDOM doesn't like [6 5] as input
```

Which is equivalent to passing a negative number to the single input form:
```
? PRINT RANDOM 10
9

? PRINT RANDOM -10
RANDOM doesn't like -10 as input
```

This change also allows negative numbers in the range:
```
? PRINT (RANDOM -10 -5)
-7

? PRINT (RANDOM -10 10)
5
```

While also enforcing the ordering constraint on the range even when negative:
```
? PRINT (RANDOM -5 -10)
RANDOM doesn't like [-5 -10] as input
```

# Test Environments
* OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
* Ubuntu Bionic (18.04.5) w/ wxWidgets 3.0.5 
* Windows 10 Pro (19045.2364) w/ wxWidgets 3.0.5