### PR TITLE
Avoid more implicit function declarations

### DIFF
--- a/wrksp.c
+++ b/wrksp.c
@@ -23,6 +23,7 @@
 #endif
 
 #include <ctype.h>
+#include <sys/wait.h>
 #ifdef WIN32
 #include <windows.h>
 #endif

--- a/xgraphics.h
+++ b/xgraphics.h
@@ -129,6 +129,9 @@ typedef struct {
   GC  pm;
 } pen_info;
 
+void save_pen(pen_info *p);
+void restore_pen(pen_info *p);
+
 extern pen_info xgr_pen;
 
 #define p_info_x(p)              (p.xpos)
@@ -152,6 +155,7 @@ extern pen_info xgr_pen;
 #define pen_down                 pen_mode=draw_gc
 
 #define button                   get_button()
+int get_button(void);
 #define mouse_x                  get_mouse_x()
 #define mouse_y                  get_mouse_y()
 


### PR DESCRIPTION
Implicit funciton declarations were removed from C99, and future compilers may not support them by default because they are a type safety hazard.

This commit fixes ucblogo for the Fedora build configure, so it will continue to build with such future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
