### PR TITLE
ISSUE-158: Configure wxWidgets to avoid linking to brew installed libraries

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -44,7 +44,7 @@ jobs:
       run: |
         mkdir build-static
         cd build-static
-        ../configure --disable-shared --enable-unicode --with-macosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        ../configure --disable-shared --enable-unicode --with-macosx-version-min=${{ env.TARGET_OSX_VERSION }} --with-libjpeg=builtin --with-libpng=builtin --without-libtiff
         make -j2
 
   build_wxwidgets_windows:


### PR DESCRIPTION
Resolves #158 

# Summary
On the GitHub MacOS runners, it looks like the installation of `brew` includes libraries which get picked up during the `wxWidgets` build. This creates a dependency for the UCBLogo binary on the `brew` installed libraries being present at runtime.

This change configures `wxWidgets` to use its `builtin` versions for `libpng` and `libjpeg` and configures it to build without `libtiff` entirely. In my first attempt, I configured `libtiff` as `builtin` but that triggered another link to a `brew` library which doesn't appear to have a `builtin` option :(

It is possible we can just compile all image libraries as `without` - willing to try that and see if there are any problems.

# Testing
Ran UCBLogo and made sure things that might have image dependencies (such as printing) continued to work as expected.

# Test Environments
* OSX Catalina (10.15.7) on Intel Core i7
* OSX Ventura (13.2.1) w/ Rosetta on Apple M2