### PR TITLE
Configure wxWidgets OSX build to avoid linking to brew installed regex library

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -78,7 +78,7 @@ jobs:
       run: |
         mkdir build-static
         cd build-static
-        ../configure --disable-shared --enable-unicode --with-macosx-version-min=${{ env.TARGET_OSX_VERSION }} --with-libjpeg=builtin --with-libpng=builtin --without-libtiff
+        ../configure --disable-shared --enable-unicode --with-macosx-version-min=${{ env.TARGET_OSX_VERSION }} --with-libjpeg=builtin --with-libpng=builtin --with-regex=builtin --without-libtiff
         make -j2
 
   build_wxwidgets_windows:


### PR DESCRIPTION
Adds `--with-regex=builtin` to CD build for wxWidgets on OSX to prevent dynamic linking to the homebrew installed library on the GitHub action runners. Similar to issue #158  and #161

# Test Environments
* OSX Catalina (10.15.7) w/ wxWidgets 3.2.2.1 on Intel Core i7
* OSX Ventura (13.2.1) w/ Rosetta w/ wxWidgets 3.2.2.1 on Apple M2