### PR TITLE
ISSUE-72: On OSX, disable smart quotes in the editor.

### DIFF
--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -42,6 +42,14 @@ wxTextCtrl(f, a, s, p, sz, b)
 	prevFind=0;
 	this->font = font;
 	SetFont(font);
+
+	// As of wxWidgets 3.1.1, there is support for selectively disabling OSX smart substitutions on text widgets.
+	// Smart substitution, particularly of quotes, causes bugs when editing code.
+#ifdef __WXOSX__
+#if wxCHECK_VERSION(3, 1, 1)
+	OSXDisableAllSmartSubstitutions();
+#endif // wxCHECK_VERSION
+#endif // __WXOSX__
 }
 
 void TextEditor::SetFont(wxFont font){


### PR DESCRIPTION
Resolves #72 
Resolves #162 

# Summary
OSX provides smart quotes by default systemwide. Under wxWidgets 3.0.x, there does not appear to be a clear approach to disabling this. Under wxWidgets 3.2.x, it is possible to selectively override the systemwide setting on a per text control basis.

# Testing
Used the test plan outlined in issue #72 and verified that:
1. On OSX w/ wxWidgets 3.2.x, the text control no longer does smart quote substitution regardless of the systemwide setting.
2. In other cases, the behavior remains the same as it was previously.


# Test Environments
* OSX Catalina (10.15.7) w/ wxWidgets 3.0.5
* OSX Catalina (10.15.7) w/ wxWidgets 3.2.2.1
* Windows 10 Pro (19045.2364) w/ wxWidgets 3.2.2.1
* Ubuntu Jammy (22.04) w/ wxWidgets 3.0.5
* Ubuntu Kinetic (22.10) w/ wxWidgets 3.2.0