### PR TITLE
Define SIG_TAKES_ARG in unix.

### DIFF
--- a/logo.h
+++ b/logo.h
@@ -69,6 +69,7 @@
 #ifndef unix
 #define unix
 #endif
+#define SIG_TAKES_ARG
 #include "config.h"
 #ifndef X_DISPLAY_MISSING
 #define x_window


### PR DESCRIPTION
This fixes one of the problems in #176 by using SIG_TAKES_ARG for unix.