### PR TITLE
Fix CD pipeline builds for OSX and Windows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -208,7 +208,8 @@ jobs:
       working-directory: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
       run: |
         cd build-static
-        make install
+        sudo make install
+        sudo cp ../wxwin.m4 /opt/homebrew/share/aclocal/
     - name: Checkout Repository
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,7 +8,6 @@ on:
     - release*
 
 env:
-  INNO_VERSION: 6.1.2
   WX_WIDGETS_VERSION: 3.2.2.1
   TARGET_OSX_VERSION: 10.14
 
@@ -236,33 +235,9 @@ jobs:
         name: ucblogo.dmg
         path: ucblogo.dmg
 
-  download_inno_windows:
-    name: Download Inno for Windows
-    runs-on: windows-latest
-    timeout-minutes: 5
-    steps:
-    - name: Cache inno
-      uses: actions/cache@v3
-      id: inno-cache
-      with:
-        path: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
-        key: ${{ runner.os }}-innosetup-${{ env.INNO_VERSION }}
-    - name: Install Dependencies
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW32
-    - name: Download inno
-      if: steps.inno-cache.outputs.cache-hit != 'true'
-      working-directory: ${{ runner.temp }}
-      shell: msys2 {0}
-      run: |
-        mkdir innosetup-${{ env.INNO_VERSION }}
-        cd innosetup-${{ env.INNO_VERSION }}
-        wget -q https://files.jrsoftware.org/is/6/innosetup-${{ env.INNO_VERSION }}.exe
-
   build_windows:
     name: Build Logo for Windows
-    needs: [ download_inno_windows, build_wxwidgets_windows, build_linux ]
+    needs: [ build_wxwidgets_windows, build_linux ]
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -275,17 +250,6 @@ jobs:
           base-devel
           mingw-w64-i686-toolchain
           unzip
-    - name: Inno Cache
-      uses: actions/cache@v3
-      id: inno-cache
-      with:
-        path: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
-        key: ${{ runner.os }}-innosetup-${{ env.INNO_VERSION }}
-    - name: Install Inno
-      working-directory: ${{ runner.temp }}\innosetup-${{ env.INNO_VERSION }}
-      shell: pwsh
-      run: |
-        ./innosetup-${{ env.INNO_VERSION }}.exe /SP- /VERYSILENT /ALLUSERS /SUPPRESSMSGBOXES
     - name: wxWidgets Cache
       uses: actions/cache@v3
       id: wxwidgets-cache

--- a/coms.c
+++ b/coms.c
@@ -445,9 +445,7 @@ NODE *lwait(NODE *args) {
 	n = (unsigned int)getint(num) * 100 / 6; // milliseconds
 	wxLogoSleep(n);
 	//check_throwing;
-	return(UNBOUND); 
-#endif
-
+#else
 	if (getint(num) > 0) {
 #ifdef unix
 #ifdef HAVE_USLEEP
@@ -485,8 +483,9 @@ NODE *lwait(NODE *args) {
 		if (n > 0) sleep(n);
 	    }
 	    input_blocking = 0;
-#endif
+#endif /* unix */
 	}
+#endif /* HAVE_WX */
     }
     return(UNBOUND);
 }


### PR DESCRIPTION
Fixed a few things preventing the CD pipeline from running successfully.

## OSX
Relatively small tweaks to the way wxWidgets is installed on the build node:
1. Using `sudo` now appears to be required.
2. The homebrew install of `autoconf` needs to have the wxWidgets m4 file manually installed. 

## Windows Inno Version
Windows build nodes now provide Inno 6.3.3 as part of the default set of tools. 6.1.2 now causes some instability, so removing this and just using the provided version which seems to work fine.

## Windows sleep Function
The Windows build nodes had been treating the appearance of `sleep` in the C code as a warning; but, now seem to treat this as an error. There should be no change in runtime behavior since the `sleep` appears after a `return` statement in wxWidgets builds of the code; but, the change in macros should prevent the code that won't execute from being compiled.

## OSX Caveat
It looks like the build nodes will no longer compile for versions of OSX prior to 11 by default. I have a thought on how we may be able to continue compiling for 10.14+ rather than 11+ but wanted to get the CD pipelines back into working state before tackling that.

## Test Environments
* OSX Ventura (13.6.6)
* Windows 10 Pro (19045.4894)
