### PR TITLE
Updated remaining pipeline action versions from v3 to v4

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Cache wxWidgets
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Cache wxWidgets
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -86,7 +86,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Cache wxWidgets
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -145,7 +145,7 @@ jobs:
         texlive
         zip
     - name: wxWidgets Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -158,7 +158,7 @@ jobs:
         sudo make install
         sudo cp ../wxwin.m4 /usr/share/aclocal/
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Build Logo
@@ -197,7 +197,7 @@ jobs:
         autoconf-archive
         automake
     - name: wxWidgets Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -210,7 +210,7 @@ jobs:
         sudo make install
         sudo cp ../wxwin.m4 /opt/homebrew/share/aclocal/
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Download PDF manual
@@ -251,13 +251,13 @@ jobs:
           mingw-w64-i686-toolchain
           unzip
     - name: wxWidgets Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}\wxWidgets-${{ env.WX_WIDGETS_VERSION }}
         key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Prepare Repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Conditionally Add wxWidgets Unofficial Repo
       if: contains(matrix.wx_version, 'unofficial')
       run: |


### PR DESCRIPTION
I believe this fixes the last of the v3 -> v4 updates on the pipeline actions and fixes warnings like the following during pipeline execution:
```
 Build wxWidgets for OSX
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```