### PR TITLE
misc fixes and updates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ EXTRA_DIST = eval.h globals.h gpl_text.h LogoFrame.h logo.h		\
 # Source for utility program for regenerating ./helpfiles/ from ./usermanual
 # See below; needs to run in build environment.
 EXTRA_DIST += makehelp.c
+CLEANFILES = makehelp
 
 # Misc information, documentation, historical files, etc
 EXTRA_DIST += changes.txt config.h.msys diffscript.pl .gitignore	\

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,13 @@ AS_IF([test x${enable_gitid} = xyes],
  [AC_DEFINE([GITID],[1],[enable gitid in version])])
 AM_CONDITIONAL([GITID], [test x${enable_gitid} = xyes])
 
-m4_ifdef([WX_CONFIG_CHECK], [
+AC_MSG_CHECKING([enable_wx])
+AC_ARG_ENABLE([wx],
+       [AS_HELP_STRING([--enable-wx],[try to use wx library for graphics (default=yes)])],,[enable_wx=yes])
+AC_MSG_RESULT([$enable_wx])
+
+AS_IF([test x${enable_wx} = xyes],
+[m4_ifdef([WX_CONFIG_CHECK], [
 WX_CONFIG_OPTIONS
 
 WX_CONFIG_CHECK([3.0.0], [wxWin=1])
@@ -52,7 +58,8 @@ AM_COND_IF([WX],
   ], [
   AC_MSG_NOTICE([No WX_CONFIG_CHECK available])
   AM_CONDITIONAL([WX], [test 1 = 0])
-])
+])],
+ AM_CONDITIONAL([WX], [test 1 = 0]))
 
 
 AC_MSG_CHECKING([enable_x11])

--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,6 @@ AC_TYPE_SIZE_T
 
 dnl Checks for library functions.
 AC_CHECK_FUNCS([usleep srandom sigsetmask matherr drem irint memcpy])
-AC_PROG_GCC_TRADITIONAL
 
 AC_SUBST(WXOFILES)
 AC_SUBST(WXSRCFILES)

--- a/logo.h
+++ b/logo.h
@@ -32,6 +32,8 @@
 
 #define ecma	/* for European extended character set using parity bit */
 
+/* glibc */
+#define SIG_TAKES_ARG
 
 #ifdef WIN32
 #define ibm

--- a/wxterm.c
+++ b/wxterm.c
@@ -91,8 +91,9 @@ char wx_font_face[300] = "Courier";   //300 matches lsetfont in wxterm.c
 int wx_font_size = 12;	
 int label_height = 15;
 
-int termcap_putter(char ch) {
-    *termcap_ptr++ = ch;
+int termcap_putter(int ch) {
+    /* XXX: Should this check for any non-char values? */
+    *termcap_ptr++ = (char)ch;
     return 0;
 }
 


### PR DESCRIPTION
These are a bunch of minor patches from updating the Debian package.

The most important is to support GCC-14 and recent glibc.

The others are minor but inoffensive, things like cleaning up the generated `makehelp` binary or making it easier to disable use of the wx library (even though the underlying C code to support that configuration has rotted away.)