### PR TITLE
Change OSX CD to build a universal binary 

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -188,7 +188,7 @@ jobs:
         name: ucblogo.pdf
         path: docs/ucblogo.pdf
 
-  build_osx:
+  build_architecure_specific_osx:
     strategy:
       matrix:
         architecture: [ x86_64, arm64 ]
@@ -239,6 +239,56 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ucblogo-${{ matrix.architecture }}.dmg
+        path: ucblogo.dmg
+
+  build_universal_binary_osx:
+    name: Build universal binary for OSX
+    needs: [ build_architecure_specific_osx ]
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+    - name: Download PDF manual
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ucblogo.pdf
+        path: docs
+    - name: Download x86_64 disk image
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ucblogo-x86_64.dmg
+        path: ucblogo-x86_64
+    - name: Extract x86_64 application
+      run: |
+        hdiutil attach ucblogo-x86_64/ucblogo.dmg
+        cp -r /Volumes/UCBLogo/UCBLogo.app ucblogo-x86_64/UCBLogo.app
+        hdiutil detach /Volumes/UCBLogo
+    - name: Download arm64 disk image
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: ucblogo-arm64.dmg
+        path: ucblogo-arm64
+    - name: Extract arm64 application
+      run: |
+        hdiutil attach ucblogo-arm64/ucblogo.dmg
+        cp -r /Volumes/UCBLogo/UCBLogo.app ucblogo-arm64/UCBLogo.app
+        hdiutil detach /Volumes/UCBLogo
+    - name: Build universal application
+      run: |
+        lipo -create -output ucblogo ucblogo-x86_64/UCBLogo.app/Contents/MacOS/UCBLogo ucblogo-arm64/UCBLogo.app/Contents/MacOS/UCBLogo
+        cp -r ucblogo-arm64/UCBLogo.app UCBLogo.app
+        cp ucblogo UCBLogo.app/Contents/MacOS/UCBLogo
+    - name: Build Logo disk image
+      run: |
+        hdiutil create -size 20m -fs HFS+ -volname "UCBLogo" ucblogo_base.dmg
+        hdiutil attach ucblogo_base.dmg
+        cp -a UCBLogo.app /Volumes/UCBLogo/
+        cp docs/ucblogo.pdf /Volumes/UCBLogo/UCBLogoUserManual.pdf
+        hdiutil detach /Volumes/UCBLogo/
+        hdiutil convert ucblogo_base.dmg -format UDZO -o ucblogo.dmg
+    - name: Archive universal ucblogo.dmg
+      uses: actions/upload-artifact@v4
+      with:
+        name: ucblogo.dmg
         path: ucblogo.dmg
 
   build_windows:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -55,7 +55,10 @@ jobs:
         make -j2
 
   build_wxwidgets_osx:
-    name: Build wxWidgets for OSX
+    strategy:
+      matrix:
+        architecture: [ x86_64, arm64 ]
+    name: Build wxWidgets for OSX ${{ matrix.architecture }}
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
@@ -64,7 +67,7 @@ jobs:
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
-        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}-${{ matrix.architecture }}
     - name: Download wxWidgets
       if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
       working-directory: ${{ runner.temp }}
@@ -77,7 +80,7 @@ jobs:
       run: |
         mkdir build-static
         cd build-static
-        ../configure --disable-shared --enable-unicode --with-macosx-version-min=${{ env.TARGET_OSX_VERSION }} --with-libjpeg=builtin --with-libpng=builtin --with-regex=builtin --without-libtiff
+        ../configure --disable-shared --disable-sys-libs --enable-unicode --enable-macosx_arch=${{ matrix.architecture }} --with-macosx-version-min=${{ env.TARGET_OSX_VERSION }}
         make -j2
 
   build_wxwidgets_windows:
@@ -186,7 +189,10 @@ jobs:
         path: docs/ucblogo.pdf
 
   build_osx:
-    name: Build Logo for OSX
+    strategy:
+      matrix:
+        architecture: [ x86_64, arm64 ]
+    name: Build Logo for OSX ${{ matrix.architecture }}
     needs: [ build_wxwidgets_osx, build_linux ]
     runs-on: macos-latest
     timeout-minutes: 15
@@ -201,7 +207,7 @@ jobs:
       id: wxwidgets-cache
       with:
         path: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
-        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}
+        key: ${{ runner.os }}-wxWidgets-${{ env.WX_WIDGETS_VERSION }}-${{ matrix.architecture }}
     - name: Install wxwidgets
       # Install wxwidgets from cache on build machine so autoconf has WX_CONFIG_CHECK
       working-directory: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}
@@ -221,18 +227,18 @@ jobs:
     - name: Build Logo
       env:
         WX_CONFIG_PATH: ${{ runner.temp }}/wxWidgets-${{ env.WX_WIDGETS_VERSION }}/build-static/wx-config
-        CFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
-        CPPFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
-        CXXFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
-        LDFLAGS: -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        CFLAGS: ${{ matrix.architecture == 'x86_64' && '-arch x86_64 -masm=intel' || '' }} -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        CPPFLAGS: ${{ matrix.architecture == 'x86_64' && '-arch x86_64 -masm=intel' || '' }} -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        CXXFLAGS: ${{ matrix.architecture == 'x86_64' && '-arch x86_64 -masm=intel' || '' }} -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
+        LDFLAGS: ${{ matrix.architecture == 'x86_64' && '-arch x86_64 -masm=intel' || '' }} -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
       run: |
         autoreconf --install
         ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH
         make -j2 ucblogo.dmg
-    - name: Archive ucblogo.dmg
+    - name: Archive ucblogo.dmg ${{ matrix.architecture }}
       uses: actions/upload-artifact@v4
       with:
-        name: ucblogo.dmg
+        name: ucblogo-${{ matrix.architecture }}.dmg
         path: ucblogo.dmg
 
   build_windows:


### PR DESCRIPTION
This MR follows up on #186 to address the CD build for versions of OSX prior to 11. CD now builds two version of wxWidgets and two versions of Logo for OSX, using matrix builds to target x86 and ARM. It then adds a stage which takes the individual platform builds of OSX Logo and combines them into a universal binary build.

# Caveats
Size - this does result in a larger application file; I think there may be value in checking what can be disabled in the wxWidgets build without impacting the parts of wxWidgets used by UCB Logo.

Duplicate build logic - I'd like to not replicate the portion of the Makefile which builds the DMG into the CD file; but, I ran into some challenges in solving that and would like to mull some more. My thinking is that, in the meantime, this change will restore CD to working for the platforms it was previously working for. Understood if folks would like to hold off until the two places can be unified appropriately.

# Testing
Downloaded the universal binary produced by the CD pipeline and was able to run it on both platforms. Checked via command line that OSX sees this as a universal binary:
```text
file /Volumes/UCBLogo/UCBLogo.app/Contents/MacOS/UCBLogo 
/Volumes/UCBLogo/UCBLogo.app/Contents/MacOS/UCBLogo: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
/Volumes/UCBLogo/UCBLogo.app/Contents/MacOS/UCBLogo (for architecture x86_64):	Mach-O 64-bit executable x86_64
/Volumes/UCBLogo/UCBLogo.app/Contents/MacOS/UCBLogo (for architecture arm64):	Mach-O 64-bit executable arm64
```

# Test Environments
* OSX Catalina (10.15.7) running on Intel Core i7
* OSX Ventura (13.6.6) running on Apple M2
