### PR TITLE
Change TIME word to use gettimeofday if available

### DIFF
--- a/coms.c
+++ b/coms.c
@@ -60,7 +60,7 @@ extern int check_wx_stop(int force_yield, int pause_return_value);
 #endif
 #endif
 
-#ifdef __APPLE__
+#ifdef HAVE_GETTIMEOFDAY
 #include <sys/time.h>
 #else
 #include <time.h>
@@ -594,7 +594,7 @@ NODE *lshell(NODE *args) {
 NODE *ltime(NODE *args) {
     NODE *val;
     FLONUM fval = 0.0;
-#ifdef __APPLE__
+#ifdef HAVE_GETTIMEOFDAY
     struct timeval tp;
 
     gettimeofday(&tp, NULL);

--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,7 @@ dnl Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T
 
 dnl Checks for library functions.
-AC_CHECK_FUNCS([usleep srandom sigsetmask matherr drem irint memcpy])
+AC_CHECK_FUNCS([usleep srandom sigsetmask matherr drem irint memcpy gettimeofday])
 
 AC_SUBST(WXOFILES)
 AC_SUBST(WXSRCFILES)


### PR DESCRIPTION
Use `gettimeofday()` in preference to `time()` in `TIME` word to support microsecond resolution.

Previously this only happened on the `__APPLE__` platform, which is great, but all modern systems should support this function, and we can test it with autoconf to support ancient systems that only have `time()`, if any still exist.

So basically this just adds the autoconf test and changes `__APPLE__` to `HAVE_GETTIMEOFDAY`

This is useful for profiling logo code, E.G.

```
? PO "TIMEIT
TO TIMEIT :INSTRUCTIONS
LOCALMAKE "T1 TIME
RUN :INSTRUCTIONS
OP TIME - :T1
END

? PR TIMEIT [REPEAT 100000 [IGNORE 1 + 1]]
0.467458009719849
```

my python might be showing