### PR TITLE
Fix race between GC and case object construction

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -674,3 +674,5 @@ extern NODE *parent_list(NODE *);
 extern void dbUsual(const char*);
 
 #endif
+
+void do_gc(BOOLEAN full);

--- a/globals.h
+++ b/globals.h
@@ -674,5 +674,3 @@ extern NODE *parent_list(NODE *);
 extern void dbUsual(const char*);
 
 #endif
-
-void do_gc(BOOLEAN full);

--- a/intern.c
+++ b/intern.c
@@ -57,6 +57,7 @@ FIXNUM hash(char *s, int len) {
 NODE *make_case(NODE *casestrnd, NODE *obj) {
     NODE *new_caseobj, *clistptr;
 
+    do_gc(FALSE);
     clistptr = caselistptr__object(obj);
     new_caseobj = make_caseobj(casestrnd, obj);
     setcdr(clistptr, cons(new_caseobj, cdr(clistptr)));

--- a/intern.c
+++ b/intern.c
@@ -55,12 +55,14 @@ FIXNUM hash(char *s, int len) {
 }
 
 NODE *make_case(NODE *casestrnd, NODE *obj) {
-    NODE *new_caseobj, *clistptr;
+    NODE *new_caseobj, *clistptr, *tmp;
 
-    do_gc(FALSE);
+    tmp = cons(NIL, NIL);
     clistptr = caselistptr__object(obj);
     new_caseobj = make_caseobj(casestrnd, obj);
-    setcdr(clistptr, cons(new_caseobj, cdr(clistptr)));
+    setcar(tmp, new_caseobj);
+    setcdr(tmp, cdr(clistptr));
+    setcdr(clistptr, tmp);
     return(new_caseobj);
 }
 


### PR DESCRIPTION
Does a partial GC before constructing new case objects to ensure there are enough free nodes to finish construction and add it to a root node before the GC runs again.

Case objects must be marked twice so if the GC runs after a new case is allocated but before it is added to the hash table AND a root AND the pointer isn't found on the stack, eg because it was optimized out, then the GC may free the cases.

I was concerned this would have a negative performance impact...

~~It actually improved unit test performance by 10-20%.~~

And it does. It's way slow. I'm not sure how I produced the "improvement". 

So we probably want to find a more performant fix.