### PR TITLE
Address Sanitizer integration

### DIFF
--- a/address-sanitizer.txt
+++ b/address-sanitizer.txt
@@ -1,0 +1,71 @@
+This document describes how Address Sanitizer is integrated with ucblogo.
+
+It has become best-practice to use such tools to verify C/C++ programs to help
+ensure memory-safety, security, stability, rapid dev/text/debug cycles, etc.
+That or don't use C.
+
+Address Sanitizer (ASAN) is a runtime library developed by Google and integrated
+into GCC (and clang) which can detect various types of subtle C memory
+management bugs.
+
+ASAN instruments code by rewriting it and managing variable allocation itself.
+In order to check for stack related errors, it creates it's own "fake" stack on
+the heap and allocates most (but not all) stack variables on the fake stack.  
+
+This is transparent to pure ANSI-C code that makes no platform-specific
+assumptions. The stack is undefined behavior as far as C is concerned.
+
+Unfortunately every practical mark and sweep memory manager for C makes platform
+specific assumptions about the stack, as they must check it for accessible
+memory objects. Fortunately this is a reasonable assumption for modern desktop
+systems, which invariable feature a contiguously addressed stack on which
+automatic variable are allocated, and, with some hacks, we can get the extents
+and iterate it.
+
+Unfortunately ASAN breaks this assumption by allocating stack frames on the heap
+and putting pointers to them on the real stack, which adds a level of
+indirection.
+
+Of course Google would like to use ASAN to check Chrome, probably why they wrote
+it, and Chrome uses a typical M&S GC with stack inspection. So they added an API
+to ASAN to smooth over the differences with minor code changes. As the stack is
+marked an ASAN function checks for pointers to fake stack frames and if found
+returns the extents of the fake frame extents to also be marked.
+
+ASAN also provides an API for manually poisoning memory regions, like free NODE
+objects.
+
+In our project most of this happens in mem.c, except for getting the address of
+the bottom of the stack which is in main.c as always.
+
+ASAN adds overhead resulting in about a 2x slowdown so it's not suitable for
+production builds. Better performance can be obtained by enabling compiler
+optimizations.
+
+To build ucblogo with ASAN pass the flags in CFLAGS to the configure script, eg.
+
+    CFLAGS="-O2 -g3 -fsanitize=address -static-libasan -fno-omit-frame-pointer" CXXFLAGS="-O2 -g3 -fsanitize=address -static-libasan -fno-omit-frame-pointer" ./configure --prefix=$HOME --enable-objects
+
+then make and test as normal.
+
+To make GDB stop before exiting when ASAN hits a bug, set a breakpoint on the
+ASAN Die function
+
+    break __sanitizer::Die
+
+You may also find the following GDB breakpoints useful
+
+    break err_logo
+    dprintf mem.c:872,"free %V %V\n",nd,*nd
+    dprintf mem.c:299,"newnode %V %V\n",newnd,*newnd
+    break mem.c:299
+    commands
+        bt
+        c
+    end
+
+This will report where and when nodes are allocated and free-ed. It is especialy
+useful in conjunction with -DSERIALIZE_OBJECTS so unique objects can be tracked
+through their complete lifecycle.
+
+More useful debugging tools are given in gdb.rc

--- a/gdb.rc
+++ b/gdb.rc
@@ -1,0 +1,52 @@
+# Dump a list of all nodes in all segments.
+# Highly recommended to pipe output to a file
+# pipe dumpnodes | cat > nodes.txt
+define dumpnodes
+    set $seg=segment_list
+    while $seg
+        set $noden=0
+        while $noden < $seg->size
+            set $node = $seg->nodes + $noden
+            printf "node %V %V %V %V\n",$node->id, $node->node_type, $node, *$node
+            set $noden=$noden+1
+        end
+        set $seg=$seg->next
+    end
+end
+
+# Given an address, if it is a pointer to a fake stack variable, returns the
+# pointer to the real stack frame.
+# Otherwise returns NULL.
+# Mostly useful for checking if a variable is on the ASAN fake stack or not.
+define realstack
+    p (void*)__asan_addr_is_in_fake_stack( \
+        (void*)__asan_get_current_fake_stack(), \
+        $arg0, \
+        NULL, NULL \
+    )
+end
+
+set $NT_LIST=010000
+set $NT_TREE=0100000
+set $NT_AGGR=020000
+set $NT_EMPTY=040000
+set $NT_CASEOBJ=000001
+
+# Walk and print a NODE tree.
+define pcons
+    if $arg0
+        printf "node %14.d %V %V %V\n",$arg0->id,$arg0->node_type, $arg0,*$arg0
+        if $arg0->node_type != -1 && !($arg0->node_type & $NT_EMPTY)
+            if $arg0->node_type & $NT_TREE
+                pconstree $arg0->nunion->ncons->nobj
+            end
+            if $arg0->node_type & $NT_LIST || $arg0->node_type & $NT_AGGR
+                pconstree $arg0->nunion->ncons->ncar
+                pconstree $arg0->nunion->ncons->ncdr
+            end
+            if $arg0->node_type & $NT_CASEOBJ
+                pconstree $arg0->nunion->ncons->ncar
+            end
+        end
+    end
+end

--- a/globals.h
+++ b/globals.h
@@ -674,3 +674,5 @@ extern NODE *parent_list(NODE *);
 extern void dbUsual(const char*);
 
 #endif
+
+void do_gc(BOOLEAN full);

--- a/globals.h
+++ b/globals.h
@@ -30,7 +30,9 @@ extern int main(int, char *[]);
 extern void unblock_input(void);
 extern void delayed_int(void);
 extern NODE *command_line;
+#ifdef SERIALIZE_OBJECTS
 extern unsigned long long int next_node_id;
+#endif
 
 #if defined(SIG_TAKES_ARG)
 void logo_stop(int);
@@ -675,5 +677,3 @@ extern NODE *parent_list(NODE *);
 extern void dbUsual(const char*);
 
 #endif
-
-void do_gc(BOOLEAN full);

--- a/globals.h
+++ b/globals.h
@@ -30,6 +30,7 @@ extern int main(int, char *[]);
 extern void unblock_input(void);
 extern void delayed_int(void);
 extern NODE *command_line;
+extern unsigned long long int next_node_id;
 
 #if defined(SIG_TAKES_ARG)
 void logo_stop(int);

--- a/intern.c
+++ b/intern.c
@@ -54,7 +54,7 @@ FIXNUM hash(char *s, int len) {
     return h % HASH_LEN;
 }
 
-NODE __attribute__((optimize(0), noinline)) *make_case(NODE *casestrnd, NODE *obj) {
+NODE *make_case(NODE *casestrnd, NODE *obj) {
     NODE *new_caseobj, *clistptr, *tmp;
 
     tmp = cons(NIL, NIL);
@@ -66,7 +66,7 @@ NODE __attribute__((optimize(0), noinline)) *make_case(NODE *casestrnd, NODE *ob
     return(new_caseobj);
 }
 
-NODE __attribute__((optimize(0), noinline)) *make_object(NODE *canonical, NODE *oproc, NODE *val,
+NODE *make_object(NODE *canonical, NODE *oproc, NODE *val,
 		  NODE *plist, NODE *casestrnd) {
     NODE *temp;
 
@@ -76,7 +76,7 @@ NODE __attribute__((optimize(0), noinline)) *make_object(NODE *canonical, NODE *
     return(temp);
 }
 
-NODE __attribute__((optimize(0), noinline)) *make_instance(NODE *casend, NODE *lownd) {
+NODE *make_instance(NODE *casend, NODE *lownd) {
     NODE *obj;
     FIXNUM hashind;
 
@@ -128,7 +128,7 @@ NODE *find_case(NODE *strnd, NODE *obj) {
     else return(car(clist));
 }
 
-NODE __attribute__((optimize(0), noinline)) *intern(NODE *nd) {
+NODE *intern(NODE *nd) {
     NODE *obj, *casedes, *lownd;
 
     if (nodetype(nd) == CASEOBJ) return(nd);

--- a/intern.c
+++ b/intern.c
@@ -57,6 +57,7 @@ FIXNUM hash(char *s, int len) {
 NODE *make_case(NODE *casestrnd, NODE *obj) {
     NODE *new_caseobj, *clistptr;
 
+    do_gc(FALSE);
     clistptr = caselistptr__object(obj);
     new_caseobj = make_caseobj(casestrnd, obj);
     setcdr(clistptr, cons(new_caseobj, cdr(clistptr)));

--- a/intern.c
+++ b/intern.c
@@ -55,12 +55,14 @@ FIXNUM hash(char *s, int len) {
 }
 
 NODE *make_case(NODE *casestrnd, NODE *obj) {
-    NODE *new_caseobj, *clistptr;
+    NODE *new_caseobj, *clistptr, *tmp;
 
-    do_gc(FALSE);
+    tmp = cons(NIL, NIL);
     clistptr = caselistptr__object(obj);
     new_caseobj = make_caseobj(casestrnd, obj);
-    setcdr(clistptr, cons(new_caseobj, cdr(clistptr)));
+    setcar(tmp, new_caseobj);
+    setcdr(tmp, cdr(clistptr));
+    setcdr(clistptr, tmp);
     return(new_caseobj);
 }
 

--- a/intern.c
+++ b/intern.c
@@ -54,7 +54,7 @@ FIXNUM hash(char *s, int len) {
     return h % HASH_LEN;
 }
 
-NODE *make_case(NODE *casestrnd, NODE *obj) {
+NODE __attribute__((optimize(0), noinline)) *make_case(NODE *casestrnd, NODE *obj) {
     NODE *new_caseobj, *clistptr, *tmp;
 
     tmp = cons(NIL, NIL);
@@ -66,7 +66,7 @@ NODE *make_case(NODE *casestrnd, NODE *obj) {
     return(new_caseobj);
 }
 
-NODE *make_object(NODE *canonical, NODE *oproc, NODE *val,
+NODE __attribute__((optimize(0), noinline)) *make_object(NODE *canonical, NODE *oproc, NODE *val,
 		  NODE *plist, NODE *casestrnd) {
     NODE *temp;
 
@@ -76,7 +76,7 @@ NODE *make_object(NODE *canonical, NODE *oproc, NODE *val,
     return(temp);
 }
 
-NODE *make_instance(NODE *casend, NODE *lownd) {
+NODE __attribute__((optimize(0), noinline)) *make_instance(NODE *casend, NODE *lownd) {
     NODE *obj;
     FIXNUM hashind;
 
@@ -128,7 +128,7 @@ NODE *find_case(NODE *strnd, NODE *obj) {
     else return(car(clist));
 }
 
-NODE *intern(NODE *nd) {
+NODE __attribute__((optimize(0), noinline)) *intern(NODE *nd) {
     NODE *obj, *casedes, *lownd;
 
     if (nodetype(nd) == CASEOBJ) return(nd);

--- a/logo.h
+++ b/logo.h
@@ -244,7 +244,9 @@ struct string_block {
 #define incstrrefcnt(sh)        (((sh)->str_refcnt)++)
 #define decstrrefcnt(sh)        (--((sh)->str_refcnt))
 
-#define SERIALIZE_OBJECTS
+// Assign a unique serial number to each object allocated so that it can be
+// tracked through it's complete lifecycle.
+// #define SERIALIZE_OBJECTS
 
 typedef struct logo_node NODE;
 typedef struct logo_node {

--- a/logo.h
+++ b/logo.h
@@ -90,7 +90,7 @@ typedef enum {wrapmode, fencemode, windowmode} mode_type;
 #define UNDEFINED       Unbound
 #define END_OF_LIST     ((NODE *) 2)
 #define HASH_LEN        1021	/* a prime number */
-#define SEG_SIZE        9 /* Should be a fairly big number for optimal GC
+#define SEG_SIZE        16000 /* Should be a fairly big number for optimal GC
                                  Performance */
 #define MAX_PHYS_LINE   5000
 #define MAX_NUMBER      200	/* max number of digits in a float */

--- a/logo.h
+++ b/logo.h
@@ -90,7 +90,7 @@ typedef enum {wrapmode, fencemode, windowmode} mode_type;
 #define UNDEFINED       Unbound
 #define END_OF_LIST     ((NODE *) 2)
 #define HASH_LEN        1021	/* a prime number */
-#define SEG_SIZE        16000 /* Should be a fairly big number for optimal GC
+#define SEG_SIZE        9 /* Should be a fairly big number for optimal GC
                                  Performance */
 #define MAX_PHYS_LINE   5000
 #define MAX_NUMBER      200	/* max number of digits in a float */
@@ -243,6 +243,8 @@ struct string_block {
 #define setstrrefcnt(sh, v)     ((sh)->str_refcnt = (v))
 #define incstrrefcnt(sh)        (((sh)->str_refcnt)++)
 #define decstrrefcnt(sh)        (--((sh)->str_refcnt))
+
+#define SERIALIZE_OBJECTS
 
 typedef struct logo_node NODE;
 typedef struct logo_node {

--- a/logo.h
+++ b/logo.h
@@ -26,6 +26,13 @@
 #include "config.h"
 #endif
 
+// Address Sanitizer check
+#if defined(__has_feature)
+#   if __has_feature(address_sanitizer) // for clang
+#       define __SANITIZE_ADDRESS__ // GCC already sets this
+#   endif
+#endif
+
 /* #define OBJECTS */
 
 /* #define MEM_DEBUG */
@@ -240,6 +247,9 @@ struct string_block {
 typedef struct logo_node NODE;
 typedef struct logo_node {
     NODETYPES node_type;
+#ifdef SERIALIZE_OBJECTS
+    unsigned long long int id;
+#endif
     int my_gen; /* Nodes's Generation */ /*GC*/
     int gen_age; /* How many times to GC at this generation */
     long int mark_gc;	/* when marked */

--- a/main.c
+++ b/main.c
@@ -210,7 +210,7 @@ void set_bottom_stack(volatile NODE** bottom) {
 		// That's the address of the bottom of the real stack.
 		real_ptr = 	__asan_addr_is_in_fake_stack(
 			__asan_get_current_fake_stack(),
-			&bottom, 
+			bottom, 
 			NULL, NULL
 		);
 		// Otherwise the variable is on the real stack so treat it normally.

--- a/makehelp.c
+++ b/makehelp.c
@@ -8,10 +8,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-char line[100], line2[100], line3[100];
-char name[30] = "helpfiles/";
-char name2[30] = "helpfiles/";
-char tocname[20], tocname2[20];
+#define BUFSIZE (1024)
+
+char line[BUFSIZE], line2[BUFSIZE], line3[BUFSIZE];
+char name[BUFSIZE] = "helpfiles/";
+char name2[BUFSIZE] = "helpfiles/";
+char tocname[BUFSIZE], tocname2[BUFSIZE];
 
 int main(int argc, char **argv) {
     FILE *in=fopen("usermanual", "r");

--- a/mem.c
+++ b/mem.c
@@ -33,8 +33,8 @@ extern NODE *stack, *numstack, *expresn, *val, *parm, *catch_tag, *arg;
 #define POISON_NODE(nd) (ASAN_POISON_MEMORY_REGION(&((nd)->nunion), sizeof((nd)->nunion)))
 #define UNPOISON_NODE(nd) (ASAN_UNPOISON_MEMORY_REGION(&((nd)->nunion), sizeof((nd)->nunion)))
 #else
-#define POISON_NODE(nd) ()
-#define UNPOISON_NODE(nd) ()
+#define POISON_NODE(nd) (0)
+#define UNPOISON_NODE(nd) (0)
 #endif
 
 #ifdef PUNY
@@ -180,7 +180,7 @@ BOOLEAN valid_pointer (volatile NODE *ptr_val) {
 /* #pragma optimize("",on) */
 #endif
 
-NODETYPES __attribute__((optimize(0))) nodetype(NODE *nd) {
+NODETYPES nodetype(NODE *nd) {
     if (nd == NIL) return (PNIL);
     return(nd->node_type);
 }

--- a/mem.c
+++ b/mem.c
@@ -173,7 +173,7 @@ BOOLEAN valid_pointer (volatile NODE *ptr_val) {
 /* #pragma optimize("",on) */
 #endif
 
-NODETYPES nodetype(NODE *nd) {
+NODETYPES __attribute__((optimize(0))) nodetype(NODE *nd) {
     if (nd == NIL) return (PNIL);
     return(nd->node_type);
 }

--- a/mem.c
+++ b/mem.c
@@ -60,7 +60,7 @@ FIXNUM seg_size = SEG_SIZE;
 
 /* A new segment of nodes is added if fewer than freed_threshold nodes are
    freed in one GC run */
-#define freed_threshold ((long int)(seg_size * 0.4))
+#define freed_threshold ((size_t)(seg_size * 0.4))
 
 NODE *free_list = NIL;                /* global ptr to free node list */
 struct segment *segment_list = NULL;  /* global ptr to segment list */
@@ -153,16 +153,16 @@ BOOLEAN addseg(void) {
 
 BOOLEAN valid_pointer (volatile NODE *ptr_val) {
     struct segment* current_seg;
-    unsigned long int ptr = (unsigned long int)ptr_val;
+    size_t ptr = (size_t)ptr_val;
     FIXNUM size;
    
     if (ptr_val == NIL) return 0;
     for (current_seg = segment_list; current_seg != NULL;
 		current_seg = current_seg->next) {
 	size = current_seg->size;
-	if ((ptr >= (unsigned long int)&current_seg->nodes[0]) &&
-	    (ptr <= (unsigned long int)&current_seg->nodes[size-1]) &&
-	    ((ptr - (unsigned long int)&current_seg->nodes[0])%
+	if ((ptr >= (size_t)&current_seg->nodes[0]) &&
+	    (ptr <= (size_t)&current_seg->nodes[size-1]) &&
+	    ((ptr - (size_t)&current_seg->nodes[0])%
 	                 (sizeof(struct logo_node)) == 0))
 	    return (ptr_val->node_type != NTFREE);
     }


### PR DESCRIPTION
This PR integrates address sanitizer, the most popular memory checker for C. All C projects should be using memory checking tools. ASAN is on par with valgrind, but much faster.

ASAN requires minor code changes for garbage collectors.

1. We use the ASAN API to determine the real stack extents
2. During the mark phase we use the ASAN API to detect and descend into "fake" stack frames on the heap so they can also be marked
3. We poison free NODEs so ASAN can report illegal access to them

ASAN is only for debug builds due to added overhead, so these changes are guarded by `#ifdef __SANITIZE_ADDRESS__`.

I also threw in some GDB tools I created and fixed a couple of small bugs along the way.