### PR TITLE
Fix c23 build error from nographics.h

### DIFF
--- a/nographics.h
+++ b/nographics.h
@@ -93,7 +93,7 @@ typedef struct { int dummy; } pen_info;
 extern int pw, ph, pc, pm, pv, px, py, bg;
 extern void nop();
 
-#define logofill nop
-#define set_palette nop
-#define get_palette nop
-#define erase_screen nop
+#define logofill() nop()
+#define set_palette(i, r, g, b) nop()
+#define get_palette(i, r, g, b) nop()
+#define erase_screen() nop()


### PR DESCRIPTION
#239 

c23 no longer allows functions with no prototype, and treats an empty parameter list as (void).  This broke some macro definitions where functions with arguments were aliased to `nop`, a function without args.

This PR updates the aliases to function-like macros, and ensures nop receives 0 arguments.

## Testing

This PR addresses the nographics path.

```
./configure --disable-wx
make
```

"too many arguments to function call, expected 0, have 4" error is gone