### PR TITLE
Error out of configure if wxwin.m4 was not found by aclocal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,11 @@ AM_COND_IF([WX],
   CFLAGS="$WX_CFLAGS_ONLY $CFLAGS"
   LIBS="$WX_LIBS $LIBS"])
   ], [
-  AC_MSG_NOTICE([No WX_CONFIG_CHECK available])
+  AC_MSG_ERROR([aclocal did not find wxwin.m4, so wxWidgets cannot be detected.
+If wxWidgets is already installed, wxwin.m4 is outside aclocal's search path.
+Re-run autoreconf with ACLOCAL_PATH set to the directory holding wxwin.m4.
+
+Or configure with --disable-wx to build without graphics.])
   AM_CONDITIONAL([WX], [test 1 = 0])
 ])],
  AM_CONDITIONAL([WX], [test 1 = 0]))


### PR DESCRIPTION
#239

## Background

If `wxwin.m4` is not found at the `autoreconf --install` step, configure will silently fall back to the nographics build.  It is relatively easy for wxwin.m4 to get missed by aclocal - in my case, the homebrew wx-widgets package stores `wxwin.m4` outside the default aclocal search path.

Currently, we get an `AC_MSG_NOTICE`, but it is easy to miss given that there is a lot logged and reconf exits successfully.

## Proposed change

Instead of silently degrading, error out with a message to the user with suggested fixes:

- explicitly select nographics build (`--disable-wx`)
- ensure wxWidgets installed
- set `ACLOCAL_PATH` before running `autoreconf`

## Tested

**--enable-wx errors**

```
$ ./configure --enable-wx
   ... output omitted for brevity ...
checking enable_wx... yes
configure: error: aclocal did not find wxwin.m4, so wxWidgets cannot be detected.
If wxWidgets is already installed, wxwin.m4 is outside aclocal's search path.
Re-run autoreconf with ACLOCAL_PATH set to the directory holding wxwin.m4.

Or configure with --disable-wx to build without graphics.
```

**--disable-wx configures successfully**

```
$ ./configure --disable-wx
   ... output omitted for brevity ...
checking enable_wx... no
   ... output omitted for brevity
$ echo $?
0
```