### PR TITLE
[ez] Don't shadow fmod in nographics.h

### DIFF
--- a/nographics.h
+++ b/nographics.h
@@ -84,7 +84,6 @@ typedef struct { int dummy; } pen_info;
 #define tone(p,d) nop()
 #define get_pen_pattern(p) nop()
 #define set_pen_pattern(p) nop()
-#define fmod(x,y) x
 #define set_list_pen_pattern(p) nop()
 
 #define prepare_to_draw_turtle nop();

--- a/wxGraphics.h
+++ b/wxGraphics.h
@@ -173,13 +173,6 @@ extern void get_palette(int, unsigned int*, unsigned int*, unsigned int*);
 extern void save_pen(pen_info*), restore_pen(pen_info*);
 extern void logofill();
 
-
-
-
-/* The sparc has fmod.  So I use it. */
-/* #define fmod(x,y)                x */
-
-
 extern void nop();
 
 

--- a/xgraphics.h
+++ b/xgraphics.h
@@ -187,10 +187,6 @@ int get_button(void);
 extern void set_palette(int, unsigned int, unsigned int, unsigned int);
 extern void get_palette(int, unsigned int*, unsigned int*, unsigned int*);
 
-/* The sparc has fmod.  So I use it. */
-/* #define fmod(x,y)                x */
-
-
 extern void nop();
 
 /* Global X variables. */


### PR DESCRIPTION
fmod has been standard since C89.  Therefore, there should be no need to define it.  Additionally, this definition is defective - it is aliased to the identity.

The other graphics implementations have commented this line out. This PR also removes those comments.