### PR TITLE
Fail configure if tex is unavailable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,12 +83,23 @@ AC_ARG_ENABLE([docs],
 AC_MSG_RESULT([$enable_docs])
 AM_CONDITIONAL([DOCS], [test x${enable_docs} = xyes])
 
-dnl The PDF Manual is built with texi2dvi, which requires tex
+dnl The manual is built by makeinfo (info and html) and by texi2dvi,
+dnl which drives pdftex for the PDF.  Check for all three: texi2dvi and
+dnl makeinfo come from GNU Texinfo, pdftex from a TeX distribution, and
+dnl they are packaged separately on most systems.
 AS_IF([test x${enable_docs} = xyes],
- [AC_CHECK_PROGS([TEX], [tex], [no])
-  AS_IF([test "x$TEX" = xno],
-   [AC_MSG_ERROR([tex not found; it is required to build the PDF manual.
-Install TeX or pass --disable-docs to skip documentation.])])])
+ [docs_missing=
+  AC_CHECK_PROG([HAVE_MAKEINFO], [makeinfo], [yes], [no])
+  AS_IF([test x$HAVE_MAKEINFO = xno], [docs_missing="$docs_missing makeinfo"])
+  AC_CHECK_PROG([HAVE_TEXI2DVI], [texi2dvi], [yes], [no])
+  AS_IF([test x$HAVE_TEXI2DVI = xno], [docs_missing="$docs_missing texi2dvi"])
+  AC_CHECK_PROGS([DOCS_PDFTEX], [pdfetex pdftex], [no])
+  AS_IF([test x$DOCS_PDFTEX = xno], [docs_missing="$docs_missing pdftex"])
+  AS_IF([test -n "$docs_missing"],
+   [AC_MSG_ERROR([missing tools required to build the manual:$docs_missing
+makeinfo and texi2dvi come from GNU Texinfo; pdftex comes from a TeX
+distribution such as TeX Live or MacTeX.
+Install them, or pass --disable-docs to skip documentation.])])])
 
 dnl Enable Compiler Warnings
 AX_CFLAGS_WARN_ALL

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,13 @@ AC_ARG_ENABLE([docs],
 AC_MSG_RESULT([$enable_docs])
 AM_CONDITIONAL([DOCS], [test x${enable_docs} = xyes])
 
+dnl The PDF Manual is built with texi2dvi, which requires tex
+AS_IF([test x${enable_docs} = xyes],
+ [AC_CHECK_PROGS([TEX], [tex], [no])
+  AS_IF([test "x$TEX" = xno],
+   [AC_MSG_ERROR([tex not found; it is required to build the PDF manual.
+Install TeX or pass --disable-docs to skip documentation.])])])
+
 dnl Enable Compiler Warnings
 AX_CFLAGS_WARN_ALL
 dnl Disable a warning with many false positives; perhaps rethink later


### PR DESCRIPTION
#239 

## Background

`configure` will finish successfully if the documentation toolchain is missing, but `make` will fail.  Two issues:

- The missing dependency would ideally manifest at the configure step
- Many devs may not need the docs, so nudging them towards `--disable-docs` could save a somewhat heavy installation (`mactex` requires ~10GB)

Building the manual needs three programs:

- `makeinfo` builds `ucblogo.info` and `ucblogo.html`
- `texi2dvi` builds `ucblogo.pdf`
- `pdftex` (or `pdfetex`) is what `texi2dvi --pdf` actually runs

## Proposed change

Fail at the `configure` step, reporting every missing tool in one message, with a hint to install them or skip the documentation build (`--disable-docs`).

## Tested

no Texinfo, no TeX (configure fails, lists all three)

```
$ ./configure
    ...
checking enable_docs... yes
checking for makeinfo... no
checking for texi2dvi... no
checking for pdfetex... no
checking for pdftex... no
configure: error: missing tools required to build the manual: makeinfo texi2dvi pdftex
makeinfo and texi2dvi come from GNU Texinfo; pdftex comes from a TeX
distribution such as TeX Live or MacTeX.
Install them, or pass --disable-docs to skip documentation.
```

Texinfo installed, no TeX (configure fails, names only `pdftex`)

```
$ brew install texinfo
$ ./configure
    ...
checking enable_docs... yes
checking for makeinfo... yes
checking for texi2dvi... yes
checking for pdfetex... no
checking for pdftex... no
configure: error: missing tools required to build the manual: pdftex
makeinfo and texi2dvi come from GNU Texinfo; pdftex comes from a TeX
distribution such as TeX Live or MacTeX.
Install them, or pass --disable-docs to skip documentation.
```

TeX installed, no Texinfo (configure fails, names the Texinfo tools)

```
$ ./configure
    ...
checking enable_docs... yes
checking for makeinfo... no
checking for texi2dvi... no
checking for pdfetex... no
checking for pdftex... pdftex
configure: error: missing tools required to build the manual: makeinfo texi2dvi
makeinfo and texi2dvi come from GNU Texinfo; pdftex comes from a TeX
distribution such as TeX Live or MacTeX.
Install them, or pass --disable-docs to skip documentation.
```

docs disabled, nothing installed (configure passes, no tool checks run)

```
$ ./configure --disable-docs
   ...
checking enable_docs... no
   ... success ...
$ make
   ... success ...
```

everything installed (configure and make run successfully)

```
$ brew install texinfo
$ brew install --cask mactex
   ...
$ ./configure
   ...
checking enable_docs... yes
checking for makeinfo... yes
checking for texi2dvi... yes
checking for pdfetex... pdfetex
   ... success ...
$ make
   ... success ...
$ ls docs
   ... ucblogo.pdf ...
```
