### PR TITLE
feat: add setshape to change the cursor to a turtle shape

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ ucblogo_CPPFLAGS = $(AM_CPPFLAGS)	\
 
 ucblogo_SOURCES = coms.c error.c eval.c files.c graphics.c init.c	\
  intern.c libloc.c lists.c logodata.c main.c math.c mem.c paren.c	\
- parse.c print.c wrksp.c
+ parse.c print.c turtleshape.c wrksp.c
 
 if OBJECTS
 ucblogo_SOURCES += obj.c
@@ -74,8 +74,9 @@ dist_pixmaps_DATA = ucblogo.xpm
 
 # #include files used in build
 EXTRA_DIST = eval.h globals.h gpl_text.h LogoFrame.h logo.h		\
- nographics.h obj.h TextEditor.h wxGlobals.h wxGraphics.h wxMain.h	\
- wxTerminal.h wxCommandHistory.h wxTurtleGraphics.h xgraphics.h
+ nographics.h obj.h TextEditor.h turtleshape.h wxGlobals.h		\
+ wxGraphics.h wxMain.h wxTerminal.h wxCommandHistory.h			\
+ wxTurtleGraphics.h xgraphics.h
 
 # Source for utility program for regenerating ./helpfiles/ from ./usermanual
 # See below; needs to run in build environment.

--- a/docs/ucblogo.texi
+++ b/docs/ucblogo.texi
@@ -3737,6 +3737,7 @@ list of numbers.)
 @menu
 * SHOWTURTLE::                  
 * HIDETURTLE::                  
+* SETSHAPE::
 * CLEAN::                       
 * CLEARSCREEN::                 
 * WRAP::                        
@@ -3767,7 +3768,7 @@ ST
 
 makes the turtle visible.
 
-@node  HIDETURTLE, CLEAN, SHOWTURTLE, TURTLE AND WINDOW CONTROL
+@node  HIDETURTLE, SETSHAPE, SHOWTURTLE, TURTLE AND WINDOW CONTROL
 @unnumberedsubsec hideturtle
 @cindex hideturtle
 @cindex ht
@@ -3781,7 +3782,28 @@ makes the turtle invisible.  It's a good idea to do this while you're in
 the middle of a complicated drawing, because hiding the turtle speeds up
 the drawing substantially.
 
-@node  CLEAN, CLEARSCREEN, HIDETURTLE, TURTLE AND WINDOW CONTROL
+@node  SETSHAPE, CLEAN, HIDETURTLE, TURTLE AND WINDOW CONTROL
+@unnumberedsubsec setshape
+@cindex setshape
+
+@example
+SETSHAPE shapenumber.or.name
+@end example
+
+sets the shape in which the turtle is drawn.  The input is either a shape
+number or the name of a shape:
+
+@example
+ 0  triangle     1  turtle
+@end example
+
+The shape affects only the appearance of the turtle cursor; the turtle's
+position, heading, and pen are unchanged, as are the lines it draws.  The
+triangle is the initial shape.  See @code{SHAPE}.
+
+@xref{SHAPE} .
+
+@node  CLEAN, CLEARSCREEN, SETSHAPE, TURTLE AND WINDOW CONTROL
 @unnumberedsubsec clean
 @cindex clean
 
@@ -4027,6 +4049,7 @@ moved, resized, or overlayed.
 * SHOWNP::                      
 * SCREENMODE::                  
 * TURTLEMODE::                  
+* SHAPE::
 * LABELSIZE::
 @end menu
 
@@ -4059,7 +4082,7 @@ SCREENMODE
 outputs the word @code{TEXTSCREEN}, @code{SPLITSCREEN}, or @code{FULLSCREEN} depending
 on the current screen mode.
 
-@node TURTLEMODE, LABELSIZE, SCREENMODE, TURTLE AND WINDOW QUERIES
+@node TURTLEMODE, SHAPE, SCREENMODE, TURTLE AND WINDOW QUERIES
 @unnumberedsubsec turtlemode
 @cindex turtlemode
 
@@ -4070,7 +4093,20 @@ TURTLEMODE
 outputs the word @code{WRAP}, @code{FENCE}, or @code{WINDOW} depending on the current
 turtle mode.
 
-@node  LABELSIZE, , TURTLEMODE, TURTLE AND WINDOW QUERIES
+@node SHAPE, LABELSIZE, TURTLEMODE, TURTLE AND WINDOW QUERIES
+@unnumberedsubsec shape
+@cindex shape
+
+@example
+SHAPE
+@end example
+
+outputs the word @code{TRIANGLE} or @code{TURTLE} depending on the shape in
+which the turtle is currently drawn.  See @code{SETSHAPE}.
+
+@xref{SETSHAPE} .
+
+@node  LABELSIZE, , SHAPE, TURTLE AND WINDOW QUERIES
 @unnumberedsubsec labelsize
 @cindex labelsize
 

--- a/globals.h
+++ b/globals.h
@@ -476,6 +476,8 @@ extern NODE *lback(NODE *);
 extern NODE *lshowturtle(NODE *);
 extern NODE *lhideturtle(NODE *);
 extern NODE *lshownp(NODE *);
+extern NODE *lsetshape(NODE *);
+extern NODE *lshape(NODE *);
 extern NODE *lsetheading(NODE *);
 extern NODE *lheading(NODE *);
 extern NODE *pos_int_vector_arg(NODE *);

--- a/graphics.c
+++ b/graphics.c
@@ -43,6 +43,7 @@
 #endif /* end this whole big huge tree */
 
 #include "globals.h"
+#include "turtleshape.h"
 
 #ifdef HAVE_WX
 int drawToPrinter=0;
@@ -219,13 +220,9 @@ void check_x_low(void) {
 }
 void draw_turtle_helper(void) {
     pen_info saved_pen;
-    FLONUM real_heading;
-    int left_x, left_y, right_x, right_y, top_x, top_y;
-#if 1	/* Evan Marshall Manning <manning@alumni.caltech.edu> */
-    double cos_real_heading, sin_real_heading;
-    FLONUM delta_x, delta_y;
-#endif
-   
+    struct turtle_shape_point points[MAX_TURTLE_SHAPE_POINTS];
+    int count, i;
+
     prepare_to_draw;
     prepare_to_draw_turtle;
     save_pen(&saved_pen);
@@ -234,29 +231,16 @@ void draw_turtle_helper(void) {
     set_pen_width(1);
     set_pen_height(1);
 
-    real_heading = -turtle_heading + 90.0;
- 
-    cos_real_heading = cos((FLONUM)(real_heading*degrad));
-    sin_real_heading = sin((FLONUM)(real_heading*degrad));
- 
-    delta_x = x_scale*(FLONUM)(sin_real_heading*turtle_half_bottom);
-    delta_y = y_scale*(FLONUM)(cos_real_heading*turtle_half_bottom);
- 
-    left_x = g_round(turtle_x - delta_x);
-    left_y = g_round(turtle_y + delta_y);
- 
-    right_x = g_round(turtle_x + delta_x);
-    right_y = g_round(turtle_y - delta_y);
- 
-    top_x = g_round(turtle_x + x_scale*(FLONUM)(cos_real_heading*turtle_side));
-    top_y = g_round(turtle_y + y_scale*(FLONUM)(sin_real_heading*turtle_side));
- 
-    /* move to right, draw to left, draw to top, draw to right */
-    move_to(screen_x_center + right_x, screen_y_center - right_y);
-    line_to(screen_x_center + left_x, screen_y_center - left_y);
-    line_to(screen_x_center + top_x, screen_y_center - top_y);
-    line_to(screen_x_center + right_x, screen_y_center - right_y);
- 
+    count = turtle_shape(turtle_x, turtle_y, turtle_heading,
+			 x_scale, y_scale,
+			 screen_x_center, screen_y_center, points);
+
+    move_to(points[0].x, points[0].y);
+    for (i = 1; i < count; i++) {
+	line_to(points[i].x, points[i].y);
+    }
+    line_to(points[0].x, points[0].y);
+
     restore_pen(&saved_pen);
     done_drawing_turtle;
     done_drawing;

--- a/graphics.c
+++ b/graphics.c
@@ -175,7 +175,7 @@ void draw_turtle(void) {
     forward(-1);
     draw_turtle_helper();
     /* all that follows is for "turtle wrap" effect */
-    if ((turtle_y > turtle_top_max - turtle_height) &&
+    if ((turtle_y > turtle_top_max - turtle_shape_extent()) &&
 	    (current_mode == wrapmode)) {
 	turtle_y -= (screen_height + 1);
 	draw_turtle_helper();
@@ -183,7 +183,7 @@ void draw_turtle(void) {
 	check_x_low();
 	turtle_y += (screen_height + 1);
     }
-    if ((turtle_y < turtle_bottom_max + turtle_height) &&
+    if ((turtle_y < turtle_bottom_max + turtle_shape_extent()) &&
 	    (current_mode == wrapmode)) {
 	turtle_y += (screen_height + 1);
 	draw_turtle_helper();
@@ -202,7 +202,7 @@ void draw_turtle(void) {
 }
 
 void check_x_high(void) {
-    if ((turtle_x > turtle_right_max - turtle_height) &&
+    if ((turtle_x > turtle_right_max - turtle_shape_extent()) &&
 	    (current_mode == wrapmode)) {
 	turtle_x -= (screen_width + 1);
 	draw_turtle_helper();
@@ -211,7 +211,7 @@ void check_x_high(void) {
 }
 
 void check_x_low(void) {
-    if ((turtle_x < turtle_left_max + turtle_height) &&
+    if ((turtle_x < turtle_left_max + turtle_shape_extent()) &&
 	    (current_mode == wrapmode)) {
 	turtle_x += (screen_width + 1);
 	draw_turtle_helper();
@@ -588,6 +588,43 @@ void fix_turtle_shownness() {
 
 NODE *lshownp(NODE *args) {
     return(user_turtle_shown ? TrueName() : FalseName());
+}
+
+static int shape_index_from_name(NODE *name) {
+    int i;
+
+    for (i = 0; i < turtle_shape_count(); i++) {
+	if (compare_node(name, make_static_strnode(turtle_shape_name(i)),
+			 TRUE) == 0)
+	    return i;
+    }
+    return -1;
+}
+
+NODE *lsetshape(NODE *args) {
+    NODE *arg = car(args);
+    int shape = -1;
+
+    if (is_word(arg)) shape = shape_index_from_name(arg);
+    if (shape < 0) {
+	arg = pos_int_arg(args);
+	if (NOT_THROWING) shape = (int)getint(arg);
+    }
+    if (NOT_THROWING) {
+	BOOLEAN changed;
+
+	prepare_to_draw;
+	draw_turtle();
+	changed = set_turtle_shape(shape);
+	draw_turtle();
+	done_drawing;
+	if (!changed) err_logo(BAD_DATA, car(args));
+    }
+    return(UNBOUND);
+}
+
+NODE *lshape(NODE *args) {
+    return(make_static_strnode(turtle_shape_name(current_turtle_shape())));
 }
 
 NODE *lsetheading(NODE *arg) {

--- a/helpfiles/Makefile.am
+++ b/helpfiles/Makefile.am
@@ -35,9 +35,10 @@ dist_helpfiles_DATA = allopen allowgetset and apply arc arctan arity	\
  sentence setbackground setbg setcslsloc setcursor seteditor setfont	\
  seth setheading sethelploc setitem setlabelheight setlibloc		\
  setmargins setpalette setpc setpen setpencolor setpenpattern		\
- setpensize setpos setprefix setread setreadpos setscrunch settc	\
- settemploc settextcolor settextfont settextsize setwrite setwritepos	\
- setx setxy sety shell show shownp showturtle sin splitscreen sqrt ss	\
+ setpensize setpos setprefix setread setreadpos setscrunch setshape	\
+ settc settemploc settextcolor settextfont settextsize setwrite		\
+ setwritepos setx setxy sety shape shell show shownp showturtle sin	\
+ splitscreen sqrt ss							\
  st standout startup step stepped steppedp stop substringp sum tag	\
  test text textscreen textsize thing throw to towards trace traced	\
  tracedp transfer ts turtlemode type unbury unburyall unburyname	\

--- a/helpfiles/setshape
+++ b/helpfiles/setshape
@@ -1,0 +1,11 @@
+SETSHAPE shapenumber.or.name
+
+	sets the shape in which the turtle is drawn.  The input is either
+	a shape number or the name of a shape:
+
+	 0  triangle	 1  turtle
+
+	The shape affects only the appearance of the turtle cursor; the
+	turtle's position, heading, and pen are unchanged, as are the lines
+	it draws.  The triangle is the initial shape.  See SHAPE.
+

--- a/helpfiles/shape
+++ b/helpfiles/shape
@@ -1,0 +1,5 @@
+SHAPE
+
+	outputs the word TRIANGLE or TURTLE depending on the shape in which
+	the turtle is currently drawn.  See SETSHAPE.
+

--- a/init.c
+++ b/init.c
@@ -407,6 +407,7 @@ PRIMTYPE prims[] = {
     {"setread", 1, 1, 1, PREFIX_PRIORITY, lsetread},
     {"setreadpos", 1, 1, 1, PREFIX_PRIORITY, lsetreadpos},
     {"setscrunch", 2, 2, 2, PREFIX_PRIORITY, lsetscrunch},
+    {"setshape", 1, 1, 1, PREFIX_PRIORITY, lsetshape},
 #if defined(WIN32)|defined(HAVE_WX)
     {"settc", 2, 2, 2, PREFIX_PRIORITY, set_text_color},
     {"settextcolor", 2, 2, 2, PREFIX_PRIORITY, set_text_color},
@@ -420,6 +421,7 @@ PRIMTYPE prims[] = {
     {"setx", 1, 1, 1, PREFIX_PRIORITY, lsetx},
     {"setxy", 2, 2, 2, PREFIX_PRIORITY, lsetxy},
     {"sety", 1, 1, 1, PREFIX_PRIORITY, lsety},
+    {"shape", 0, 0, 0, PREFIX_PRIORITY, lshape},
     {"shell", 1, 1, 2, PREFIX_PRIORITY, lshell},
     {"show", 0, 1, -1, PREFIX_PRIORITY, lshow},
     {"shownp", 0, 0, 0, PREFIX_PRIORITY, lshownp},

--- a/makefile.msys
+++ b/makefile.msys
@@ -16,12 +16,12 @@ LINKER = $(CXX)
 
 OBJS	= coms.o error.o eval.o files.o graphics.o init.o intern.o \
 	  libloc.o lists.o logodata.o main.o math.o mem.o paren.o parse.o \
-	  print.o wrksp.o nographics.o git.o wxMain.o wxTerminal.o \
+	  print.o turtleshape.o wrksp.o nographics.o git.o wxMain.o wxTerminal.o \
 	  wxCommandHistory.o wxTurtleGraphics.o TextEditor.o wxterm.o
 
 SRCS	= coms.c error.c eval.c files.c graphics.c init.c intern.c config.h \
 	  libloc.c lists.c logodata.c main.c math.c mem.c paren.c parse.c \
-	  print.c wrksp.c nographics.c wxMain.cpp wxTerminal.cpp \
+	  print.c turtleshape.c wrksp.c nographics.c wxMain.cpp wxTerminal.cpp \
 	  wxCommandHistory.cpp wxTurtleGraphics.cpp TextEditor.cpp wxterm.c
 
 HDRS	= globals.h logo.h xgraphics.h

--- a/nographics.h
+++ b/nographics.h
@@ -29,8 +29,6 @@
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
 #define turtle_height 18
-#define turtle_half_bottom 6.0
-#define turtle_side 19.0
 
 #define clear_screen nop()
 

--- a/nographics.h
+++ b/nographics.h
@@ -28,8 +28,6 @@
 #define screen_x_coord ((screen_x_center) + turtle_x)
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
-#define turtle_height 18
-
 #define clear_screen nop()
 
 #define line_to(x,y) nop()

--- a/turtleshape.c
+++ b/turtleshape.c
@@ -115,6 +115,13 @@ int turtle_shape(FLONUM x, FLONUM y, FLONUM heading,
     cos_real_heading = cos((FLONUM)(real_heading*degrad));
     sin_real_heading = sin((FLONUM)(real_heading*degrad));
 
+    /* cos(90*degrad) is 6e-17 rather than zero, which is enough to tip a
+       vertex sitting on a half step across g_round's tie, so the shape and
+       its mirror land on different pixels.  Headings that are multiples of
+       ninety must come out exact. */
+    if (fabs(cos_real_heading) < 1e-12) cos_real_heading = 0.0;
+    if (fabs(sin_real_heading) < 1e-12) sin_real_heading = 0.0;
+
     for (i = 0; i < count; i++) {
 	FLONUM forward = vertices[i].forward;
 	FLONUM right = vertices[i].right;

--- a/turtleshape.c
+++ b/turtleshape.c
@@ -1,0 +1,82 @@
+/*
+ *      turtleshape.c       logo turtle shape module
+ *
+ *      This program is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License
+ *      along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <math.h>
+#include "logo.h"
+#include "globals.h"
+#include "turtleshape.h"
+
+#define TRIANGLE_HALF_BASE 6.0
+#define TRIANGLE_ALTITUDE 19.0
+
+/* Vertices in turtle steps: forward is along the turtle's heading, right
+   is ninety degrees clockwise from it. */
+static struct {
+    FLONUM forward, right;
+} local_vertices[MAX_TURTLE_SHAPE_POINTS] = {
+    { 0.0,		  TRIANGLE_HALF_BASE },	/* right base corner */
+    { 0.0,		 -TRIANGLE_HALF_BASE },	/* left base corner */
+    { TRIANGLE_ALTITUDE,  0.0 }			/* nose */
+};
+
+static int local_vertex_count = 3;
+
+int turtle_shape(FLONUM x, FLONUM y, FLONUM heading,
+		 FLONUM xscale, FLONUM yscale,
+		 int x_center, int y_center,
+		 struct turtle_shape_point *out_points) {
+    FLONUM real_heading, cos_real_heading, sin_real_heading;
+    int i;
+
+    real_heading = -heading + 90.0;
+    cos_real_heading = cos((FLONUM)(real_heading*degrad));
+    sin_real_heading = sin((FLONUM)(real_heading*degrad));
+
+    for (i = 0; i < local_vertex_count; i++) {
+	FLONUM forward = local_vertices[i].forward;
+	FLONUM right = local_vertices[i].right;
+	FLONUM delta_x = xscale*(FLONUM)(forward*cos_real_heading +
+					 right*sin_real_heading);
+	FLONUM delta_y = yscale*(FLONUM)(forward*sin_real_heading -
+					 right*cos_real_heading);
+
+	out_points[i].x = x_center + g_round(x + delta_x);
+	out_points[i].y = y_center - g_round(y + delta_y);
+    }
+
+    return local_vertex_count;
+}
+
+FLONUM turtle_shape_extent(void) {
+    FLONUM extent = 0.0;
+    int i;
+
+    for (i = 0; i < local_vertex_count; i++) {
+	FLONUM forward = local_vertices[i].forward;
+	FLONUM right = local_vertices[i].right;
+	FLONUM radius = sqrt(forward*forward + right*right);
+
+	if (radius > extent) extent = radius;
+    }
+
+    return extent;
+}

--- a/turtleshape.c
+++ b/turtleshape.c
@@ -25,25 +25,89 @@
 #include "globals.h"
 #include "turtleshape.h"
 
-#define TRIANGLE_HALF_BASE 6.0
-#define TRIANGLE_ALTITUDE 19.0
+#define count_of(a) ((int)(sizeof(a)/sizeof((a)[0])))
 
 /* Vertices in turtle steps: forward is along the turtle's heading, right
    is ninety degrees clockwise from it. */
-static struct {
+struct vertex {
     FLONUM forward, right;
-} local_vertices[MAX_TURTLE_SHAPE_POINTS] = {
+};
+
+#define TRIANGLE_HALF_BASE 6.0
+#define TRIANGLE_ALTITUDE 19.0
+
+static const struct vertex triangle_vertices[] = {
     { 0.0,		  TRIANGLE_HALF_BASE },	/* right base corner */
     { 0.0,		 -TRIANGLE_HALF_BASE },	/* left base corner */
     { TRIANGLE_ALTITUDE,  0.0 }			/* nose */
 };
 
-static int local_vertex_count = 3;
+/* Centered on the turtle's origin, head forward, going down the right side
+   and back up the left.  The nose and the tail lie on the axis, so each is a
+   single vertex rather than a mirrored pair. */
+static const struct vertex turtle_vertices[] = {
+    {   14.0,   0.0 },	/* nose */
+    {  10.25,   2.5 },
+    {    8.5,  1.75 },
+    {   7.25,   5.0 },
+    {    8.0,   9.0 },
+    {    3.0,  13.5 },	/* right front flipper */
+    {    4.0,   7.0 },
+    {    0.0,  8.25 },	/* widest point of the shell */
+    {   -7.0,   6.0 },
+    {  -8.75,   8.0 },
+    {  -12.5,  4.25 },	/* right rear flipper */
+    {   -8.5,  4.25 },
+    {  -10.0,   1.0 },
+    { -13.25,   0.0 },	/* tail */
+    {  -10.0,  -1.0 },
+    {   -8.5, -4.25 },
+    {  -12.5, -4.25 },	/* left rear flipper */
+    {  -8.75,  -8.0 },
+    {   -7.0,  -6.0 },
+    {    0.0, -8.25 },	/* widest point of the shell */
+    {    4.0,  -7.0 },
+    {    3.0, -13.5 },	/* left front flipper */
+    {    8.0,  -9.0 },
+    {   7.25,  -5.0 },
+    {    8.5, -1.75 },
+    {  10.25,  -2.5 }
+};
+
+/* No shape may have more than MAX_TURTLE_SHAPE_POINTS vertices. */
+static const struct {
+    char *name;
+    int count;
+    const struct vertex *vertices;
+} shapes[] = {
+    { "triangle", count_of(triangle_vertices), triangle_vertices },
+    { "turtle",   count_of(turtle_vertices),   turtle_vertices }
+};
+
+static int current_shape = 0;
+static FLONUM current_extent = TRIANGLE_ALTITUDE;
+
+static FLONUM extent_of(int shape) {
+    FLONUM extent = 0.0;
+    int i;
+
+    for (i = 0; i < shapes[shape].count; i++) {
+	FLONUM forward = shapes[shape].vertices[i].forward;
+	FLONUM right = shapes[shape].vertices[i].right;
+	FLONUM radius = sqrt(forward*forward + right*right);
+
+	if (radius > extent) extent = radius;
+    }
+
+    return extent;
+}
 
 int turtle_shape(FLONUM x, FLONUM y, FLONUM heading,
 		 FLONUM xscale, FLONUM yscale,
 		 int x_center, int y_center,
 		 struct turtle_shape_point *out_points) {
+    const struct vertex *vertices = shapes[current_shape].vertices;
+    int count = shapes[current_shape].count;
     FLONUM real_heading, cos_real_heading, sin_real_heading;
     int i;
 
@@ -51,9 +115,9 @@ int turtle_shape(FLONUM x, FLONUM y, FLONUM heading,
     cos_real_heading = cos((FLONUM)(real_heading*degrad));
     sin_real_heading = sin((FLONUM)(real_heading*degrad));
 
-    for (i = 0; i < local_vertex_count; i++) {
-	FLONUM forward = local_vertices[i].forward;
-	FLONUM right = local_vertices[i].right;
+    for (i = 0; i < count; i++) {
+	FLONUM forward = vertices[i].forward;
+	FLONUM right = vertices[i].right;
 	FLONUM delta_x = xscale*(FLONUM)(forward*cos_real_heading +
 					 right*sin_real_heading);
 	FLONUM delta_y = yscale*(FLONUM)(forward*sin_real_heading -
@@ -63,20 +127,30 @@ int turtle_shape(FLONUM x, FLONUM y, FLONUM heading,
 	out_points[i].y = y_center - g_round(y + delta_y);
     }
 
-    return local_vertex_count;
+    return count;
 }
 
 FLONUM turtle_shape_extent(void) {
-    FLONUM extent = 0.0;
-    int i;
+    return current_extent;
+}
 
-    for (i = 0; i < local_vertex_count; i++) {
-	FLONUM forward = local_vertices[i].forward;
-	FLONUM right = local_vertices[i].right;
-	FLONUM radius = sqrt(forward*forward + right*right);
+int turtle_shape_count(void) {
+    return count_of(shapes);
+}
 
-	if (radius > extent) extent = radius;
-    }
+char *turtle_shape_name(int shape) {
+    if (shape < 0 || shape >= count_of(shapes)) return NULL;
+    return shapes[shape].name;
+}
 
-    return extent;
+int current_turtle_shape(void) {
+    return current_shape;
+}
+
+BOOLEAN set_turtle_shape(int shape) {
+    if (shape < 0 || shape >= count_of(shapes)) return FALSE;
+
+    current_shape = shape;
+    current_extent = extent_of(shape);
+    return TRUE;
 }

--- a/turtleshape.h
+++ b/turtleshape.h
@@ -1,0 +1,57 @@
+/*
+ *      turtleshape.h       logo turtle shape module
+ *
+ *      This program is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License
+ *      along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef _TURTLESHAPE_H
+#define _TURTLESHAPE_H
+
+#include "logo.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_TURTLE_SHAPE_POINTS 128
+
+struct turtle_shape_point {
+    int x, y;
+};
+
+/* Compute the outline of the turtle as a closed polygon.
+
+     x, y                turtle coordinates of the turtle's origin
+     heading             Logo degrees, clockwise from north
+     xscale, yscale      pixels per turtle step
+     x_center, y_center  screen position of the turtle's origin
+     out_points          filled with the outline; needs room for
+                         MAX_TURTLE_SHAPE_POINTS entries
+
+   Returns the number of vertices written. */
+extern int turtle_shape(FLONUM x, FLONUM y, FLONUM heading,
+			FLONUM xscale, FLONUM yscale,
+			int x_center, int y_center,
+			struct turtle_shape_point *out_points);
+
+/* The radius of the smallest circle centered on the turtle's origin that
+   contains the whole shape, in turtle steps. */
+extern FLONUM turtle_shape_extent(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _TURTLESHAPE_H */

--- a/turtleshape.h
+++ b/turtleshape.h
@@ -50,6 +50,12 @@ extern int turtle_shape(FLONUM x, FLONUM y, FLONUM heading,
    contains the whole shape, in turtle steps. */
 extern FLONUM turtle_shape_extent(void);
 
+/* Shapes are numbered from zero; shape zero is the default. */
+extern int turtle_shape_count(void);
+extern char *turtle_shape_name(int shape);	/* NULL if out of range */
+extern int current_turtle_shape(void);
+extern BOOLEAN set_turtle_shape(int shape);	/* FALSE if out of range */
+
 #ifdef __cplusplus
 }
 #endif

--- a/usermanual
+++ b/usermanual
@@ -1745,6 +1745,17 @@ HT
 	you're in the middle of a complicated drawing, because hiding
 	the turtle speeds up the drawing substantially.
 
+SETSHAPE shapenumber.or.name
+
+	sets the shape in which the turtle is drawn.  The input is either
+	a shape number or the name of a shape:
+
+	 0  triangle	 1  turtle
+
+	The shape affects only the appearance of the turtle cursor; the
+	turtle's position, heading, and pen are unchanged, as are the lines
+	it draws.  The triangle is the initial shape.  See SHAPE.
+
 CLEAN
 
 	erases all lines that the turtle has drawn on the graphics window.
@@ -1903,6 +1914,11 @@ TURTLEMODE
 
 	outputs the word WRAP, FENCE, or WINDOW depending on the current
 	turtle mode.
+
+SHAPE
+
+	outputs the word TRIANGLE or TURTLE depending on the shape in which
+	the turtle is currently drawn.  See SETSHAPE.
 
 LABELSIZE
 

--- a/win32trm.h
+++ b/win32trm.h
@@ -50,8 +50,6 @@
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
 #define turtle_height (FIXNUM) 18
-#define turtle_half_bottom (FLONUM) 6.0
-#define turtle_side (FLONUM) 19.0
 
 #define clear_screen win32_erase_screen()
 

--- a/win32trm.h
+++ b/win32trm.h
@@ -49,8 +49,6 @@
 #define screen_x_coord ((screen_x_center) + turtle_x)
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
-#define turtle_height (FIXNUM) 18
-
 #define clear_screen win32_erase_screen()
 
 #define line_to(x,y) {\

--- a/wxGraphics.h
+++ b/wxGraphics.h
@@ -81,8 +81,6 @@ extern void doFilled(int fillcolor, int count, struct mypoint *points);
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
 #define turtle_height 18
-#define turtle_half_bottom 6.0
-#define turtle_side 19.0
 
 #define refresh_screen()         wx_refresh();
 #define clear_screen		 wx_clear();

--- a/wxGraphics.h
+++ b/wxGraphics.h
@@ -80,8 +80,6 @@ extern void doFilled(int fillcolor, int count, struct mypoint *points);
 #define screen_x_coord ((screen_x_center) + turtle_x)
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
-#define turtle_height 18
-
 #define refresh_screen()         wx_refresh();
 #define clear_screen		 wx_clear();
 

--- a/wxTurtleGraphics.cpp
+++ b/wxTurtleGraphics.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include "wxTurtleGraphics.h"
 #include "TextEditor.h"
+#include "turtleshape.h"
 #include <wx/stdpaths.h>
 #define WX_TURTLEGRAPHICS_CPP 1
 
@@ -318,57 +319,29 @@ void TurtleCanvas::OnSize(wxSizeEvent& event) {
 extern FLONUM turtle_x, turtle_y, turtle_heading;
 extern "C" FLONUM x_scale, y_scale;
 extern "C" BOOLEAN user_turtle_shown;
-extern "C" FIXNUM g_round(FLONUM n);
 
 void TurtleCanvas::DrawTurtle(wxDC &dc) {
-  FLONUM real_heading;
-  int left_x, left_y, right_x, right_y, top_x, top_y;
-  double cos_real_heading, sin_real_heading;
-  FLONUM delta_x, delta_y;
   if (!user_turtle_shown) {
     return;
   }
-  const FLONUM degrad = 0.017453292520;
   const int screen_width = wxGetInfo(SCREEN_WIDTH);
   const int screen_height = wxGetInfo(SCREEN_HEIGHT);
   const int screen_top = 0;
   const int screen_left = 0;
-  const FLONUM turtle_side = 19.0;
-  const FLONUM turtle_half_bottom = 6.0;
   const int screen_x_center = (screen_left + (screen_width)/2);
   const int screen_y_center = (screen_top + (screen_height)/2);
 
-  real_heading = -turtle_heading + 90.0;
+  struct turtle_shape_point points[MAX_TURTLE_SHAPE_POINTS];
+  const int count = turtle_shape(turtle_x, turtle_y, turtle_heading,
+				 x_scale, y_scale,
+				 screen_x_center, screen_y_center, points);
 
-  cos_real_heading = cos((FLONUM)(real_heading*degrad));
-  sin_real_heading = sin((FLONUM)(real_heading*degrad));
-
-  delta_x = x_scale*(FLONUM)(sin_real_heading*turtle_half_bottom);
-  delta_y = y_scale*(FLONUM)(cos_real_heading*turtle_half_bottom);
-
-  left_x = g_round(turtle_x - delta_x);
-  left_y = g_round(turtle_y + delta_y);
-
-  right_x = g_round(turtle_x + delta_x);
-  right_y = g_round(turtle_y - delta_y);
-
-  top_x = g_round(turtle_x + x_scale*(FLONUM)(cos_real_heading*turtle_side));
-  top_y = g_round(turtle_y + y_scale*(FLONUM)(sin_real_heading*turtle_side));
-
-  /* move to right, draw to left, draw to top, draw to right */
-  //move_to(screen_x_center + right_x, screen_y_center - right_y);
-  //line_to(screen_x_center + left_x, screen_y_center - left_y);
   dc.SetPen(wxPen(colors[turtleFrame->xgr_pen.color+SPECIAL_COLORS],
 		  turtleFrame->xgr_pen.pw, wxPENSTYLE_SOLID));
-  dc.DrawLine(screen_x_center + right_x, screen_y_center - right_y,
-	      screen_x_center + left_x, screen_y_center - left_y);
-  //line_to(screen_x_center + top_x, screen_y_center - top_y);
-  dc.DrawLine(screen_x_center + left_x, screen_y_center - left_y,
-	      screen_x_center + top_x, screen_y_center - top_y);
-  //line_to(screen_x_center + right_x, screen_y_center - right_y);
-  dc.DrawLine(screen_x_center + top_x, screen_y_center - top_y,
-	      screen_x_center + right_x, screen_y_center - right_y);
-
+  for (int i = 0; i < count; i++) {
+    int j = (i + 1) % count;
+    dc.DrawLine(points[i].x, points[i].y, points[j].x, points[j].y);
+  }
 }
 
 void TurtleCanvas::OnDraw(wxDC &dc) {

--- a/xgraphics.h
+++ b/xgraphics.h
@@ -64,8 +64,6 @@ extern void placate_x();
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
 #define turtle_height 18
-#define turtle_half_bottom 6.0
-#define turtle_side 19.0
 
 #define clear_screen		 XClearWindow(dpy, win)
 

--- a/xgraphics.h
+++ b/xgraphics.h
@@ -63,8 +63,6 @@ extern void placate_x();
 #define screen_x_coord ((screen_x_center) + turtle_x)
 #define screen_y_coord ((screen_y_center) - turtle_y)
 
-#define turtle_height 18
-
 #define clear_screen		 XClearWindow(dpy, win)
 
 #define erase_screen()		 XClearWindow(dpy, win)


### PR DESCRIPTION
As discussed in #238, I wanted to add a turtle-shaped cursor to UCB logo.

The API follows the setter/getter pattern followed by other commands.  The only shapes available are the existing triangle (default) and the turtle.

A small refactor in here: I deduplicate some code between graphics.c and wxTurtleGraphics - the turtle-drawing code was defined in both places because the XOR drawing is not well supported with wx.

<img width="69" height="70" alt="Screenshot 2026-08-16 at 11 05 16 AM" src="https://github.com/user-attachments/assets/733383b0-dd5c-43e9-931b-f5c3bf6da442" />

<img width="104" height="156" alt="Screenshot 2026-08-16 at 11 05 45 AM" src="https://github.com/user-attachments/assets/465d286d-2bad-495e-8b50-ec87cdf1fb83" />

I'm not attached to the exact shape - I just wanted something that looks like a turtle and aimed for relatively few points.