### PR TITLE
Fix macOS/BSD build: use tcgetattr/tcsetattr instead of Linux-only TCGETA/TCSETA ioctls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Makefile.in
 *.exe
 git.c
 logo_win.res
+*.dSYM/

--- a/term.c
+++ b/term.c
@@ -124,7 +124,13 @@ void term_init(void) {
 #endif
 
     if (interactive) {
-#if defined(HAVE_TERMIO_H) || defined(HAVE_TERMIOS_H)
+#if defined(HAVE_TERMIOS_H)
+	tcgetattr(0, &tty_cooked);
+	tty_cbreak = tty_cooked;
+	tty_cbreak.c_cc[VMIN] = '\01';
+	tty_cbreak.c_cc[VTIME] = '\0';
+	tty_cbreak.c_lflag &= ~(ECHO|ICANON);
+#elif defined(HAVE_TERMIO_H)
 	ioctl(0,TCGETA,(char *)(&tty_cooked));
 	tty_cbreak = tty_cooked;
 	tty_cbreak.c_cc[VMIN] = '\01';
@@ -184,7 +190,9 @@ void term_init(void) {
 void charmode_on() {
 #ifdef unix
     if ((readstream == stdin) && interactive && !tty_charmode) {
-#if defined(HAVE_TERMIO_H) || defined(HAVE_TERMIOS_H)
+#if defined(HAVE_TERMIOS_H)
+	tcsetattr(0, TCSANOW, &tty_cbreak);
+#elif defined(HAVE_TERMIO_H)
 	ioctl(0,TCSETA,(char *)(&tty_cbreak));
 #else /* !HAVE_TERMIO_H */
 	ioctl(0,TIOCSETP,(char *)(&tty_cbreak));
@@ -200,7 +208,9 @@ void charmode_on() {
 void charmode_off() {
 #ifdef unix
     if (tty_charmode) {
-#if defined(HAVE_TERMIO_H) || defined(HAVE_TERMIOS_H)
+#if defined(HAVE_TERMIOS_H)
+	tcsetattr(0, TCSANOW, &tty_cooked);
+#elif defined(HAVE_TERMIO_H)
 	ioctl(0,TCSETA,(char *)(&tty_cooked));
 #else /* !HAVE_TERMIO_H */
 	ioctl(0,TIOCSETP,(char *)(&tty_cooked));


### PR DESCRIPTION
## Summary
- `term.c` used the Linux-only `TCGETA`/`TCSETA` ioctl request codes whenever
  `HAVE_TERMIO_H` *or* `HAVE_TERMIOS_H` was defined. Those constants exist on
  Linux (kept for compat with the old System V `termio` API) but not on
  macOS/BSD, which only implement the POSIX `termios` API via
  `tcgetattr()`/`tcsetattr()`. Result: `./configure && make` fails to build on
  macOS out of the box with `error: use of undeclared identifier 'TCGETA'`.
- Split the `HAVE_TERMIOS_H` case out to use the POSIX `tcgetattr()`/
  `tcsetattr()` calls instead. The `HAVE_TERMIO_H`-without-`termios`
  fallback (old System V, no POSIX termios) keeps using the original ioctl
  approach unchanged, so this doesn't affect any platform that was already
  building successfully.

## Test plan
- Built from a clean clone on macOS 26 (Apple Silicon) with both
  `--disable-wx` (console) and the default wxWidgets GUI build; both compile
  and run correctly after this change, neither did before it.
