### PR TITLE
Fix memory corruption in headless (nographics) build

### DIFF
--- a/graphics.c
+++ b/graphics.c
@@ -153,6 +153,16 @@ void draw_turtle(void) {
     return;
 #endif
 
+#if !defined(HAVE_WX) && !defined(WIN32) && !defined(x_window)
+    // No real graphics backend (headless/nographics build): there is no
+    // turtle icon to actually draw, and the recursive forward(-1)/
+    // forward(1) calls below (used elsewhere to erase/redraw the turtle
+    // shape) serve no purpose here -- they only risk unbounded recursion
+    // through forward() once turtle_shown becomes true. Mirror the
+    // HAVE_WX early-out above.
+    return;
+#endif
+
     if (!turtle_shown) {
 		if (!graphics_setup) {
 			graphics_setup++;
@@ -1649,6 +1659,19 @@ NODE *lprinttext(NODE *args) {
 
 BOOLEAN safe_to_save(void) {
     char *newbuf;
+
+#if !defined(HAVE_WX) && !defined(WIN32) && !defined(x_window)
+    // No real graphics backend (headless/nographics build): nographics.h
+    // defines GR_SIZE as 1, so record_buffer (declared as
+    // char record_buffer[GR_SIZE]) is a single byte -- yet the code below
+    // unconditionally writes a full pointer into it on the very first
+    // call, corrupting whatever global follows record_buffer in memory
+    // (observed: silently stomps AllowGetSet, causing an unrelated crash
+    // on a later, seemingly unrelated primitive lookup). There is no
+    // window to redraw in a headless build anyway, so there is nothing
+    // to gain from recording draw operations here.
+    return FALSE;
+#endif
 
     if (!refresh_p || drawing_turtle) return FALSE;
     if (record == 0) {	/* first time */


### PR DESCRIPTION
## Summary
Any procedure containing 2+ turtle-movement calls (`fd`/`back`) crashes a `--disable-wx` (nographics) build with `EXC_BAD_ACCESS`.

Root-caused with lldb: `nographics.h` defines `GR_SIZE` as `1` ("a dummy graphics header file for computers without graphics"), so `graphics.c`'s `char record_buffer[GR_SIZE];` is a single byte -- but `safe_to_save()` (called from `save_line()`/`save_move()`, not gated by any nographics-specific stub) writes a full 8-byte pointer into it on the very first call, silently corrupting whatever global follows `record_buffer` in memory (observed: `AllowGetSet`). The corruption doesn't crash immediately -- it surfaces later, on some unrelated evaluator lookup that happens to read the now-garbage pointer, which made this confusing to trace back to its actual cause (looks like the *second* movement command crashes, not the first).

`fd`/`back` are the only movement primitives that go through `forward_helper()` (and thus `save_line()`/`save_move()`); `rt`/`lt` don't call it at all, which is why a procedure with only turns never triggered this.

## Fix
Make `safe_to_save()` an unconditional no-op for headless builds, mirroring the existing `HAVE_WX`-only early-return already in `draw_turtle()` a few lines above it. There's no window to ever redraw in a headless build, so recording draw operations for later replay serves no purpose there -- bumping `GR_SIZE` instead would only move the overflow further out, not fix the underlying mismatch.

Also added the equivalent early-return to `draw_turtle()` itself for headless builds (previously only guarded for `HAVE_WX`) -- turned out not to be this bug's cause once traced with lldb, but it's the same class of issue (recursing through `forward()` with nothing to actually draw) and worth closing off regardless.

## Test plan
Verified with `koch 150 4` (256 nested `fd`/`lt`/`rt` calls from a self-recursive procedure) -- previously crashed immediately, now completes cleanly with a correct final turtle position.

Related to (does not fully explain) #245, which covers a distinct, not-yet-root-caused issue in the wx build.