### PR TITLE
Disabling building docs in mac build.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -233,7 +233,7 @@ jobs:
         LDFLAGS: ${{ matrix.architecture == 'x86_64' && '-arch x86_64 -masm=intel' || '' }} -mmacosx-version-min=${{ env.TARGET_OSX_VERSION }}
       run: |
         autoreconf --install
-        ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH
+        ./configure --enable-gitid --with-wx-config=$WX_CONFIG_PATH --disable-docs
         make -j2 ucblogo.dmg
     - name: Archive ucblogo.dmg ${{ matrix.architecture }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Attempting to fix: https://github.com/jrincayc/ucblogo-code/actions/runs/33891497486/job/101084588993

```
checking enable_x11... no
configure: error: missing tools required to build the manual: makeinfo texi2dvi pdftex
checking enable_docs... yes
makeinfo and texi2dvi come from GNU Texinfo; pdftex comes from a TeX
checking for makeinfo... no
distribution such as TeX Live or MacTeX.
checking for texi2dvi... no
checking for pdfetex... no
checking for pdftex... no
Install them, or pass --disable-docs to skip documentation.
Error: Process completed with exit code 1.
```